### PR TITLE
fix: InodeCompact struct had invalid size

### DIFF
--- a/internal/disk/types.go
+++ b/internal/disk/types.go
@@ -56,7 +56,6 @@ type InodeCompact struct {
 	Size         uint32
 	Reserved     uint32
 	InodeData    uint32
-	RawBlockSize uint16
 	Inode        uint32
 	UID          uint16
 	GID          uint16


### PR DESCRIPTION
fixes:
- https://github.com/erofs/go-erofs/issues/2