### PR TITLE
Add image builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,82 @@
 # go-erofs
 
-A Go library for opening erofs files as a Go stdlib [fs.FS](https://pkg.go.dev/io/fs#FS).
+A Go library for reading and creating [EROFS](https://erofs.docs.kernel.org/) filesystem images using the standard [fs.FS](https://pkg.go.dev/io/fs#FS) interface.
 
-## Scope
+## Features
 
-This library is designed to allow erofs files to be usable in any Go operation that uses
-the standard filesystem interface. This could be useful for accessing an erofs file just
-as you would a plain directory without needing to unpack. In the future this library
-could provide an interface to create erofs files as well.
+- **Read** EROFS images through Go's `fs.FS` interface
+- **Create** EROFS images from directories or any `fs.FS`
+- **Merge** multiple filesystem sources with overlay whiteout support
+- **Metadata-only** mode for container layer indexing (chunk-based references to original data)
+- Pure Go, no CGO — uses only the standard library
 
-## Current state
+### Status
 
 - [x] Read erofs files created with default `mkfs.erofs` options
-- [x] Read chunk-based erofs files (without indexes)
-- [x] Xattr support
-- [x] Long xattr prefix support
-- [x] Extra devices for chunked data and chunk indexes
+- [x] Read chunk-based erofs files with indexes
+- [x] Xattr support including long xattr prefixes
+- [x] Extra devices for chunked data
+- [x] Create erofs files from any `fs.FS`
+- [x] Directory to erofs packing
+- [x] AUFS whiteout to overlayfs conversion
+- [x] Merge multiple filesystem layers with whiteout processing
 - [ ] Read erofs files with compression
-- [ ] Creating erofs files
-- [ ] Tar to erofs conversion
 
-## Example use
+## Reading an EROFS image
 
-Print out all the files in an erofs file
-
-```
-package main
-
-import (
-	"fmt"
-	"io/fs"
-	"log"
-	"os"
-
-	"github.com/erofs/go-erofs"
-)
-
-func main() {
-	f, err := os.Open("testdata/basic-default.erofs")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer f.Close()
-
-	img, err := erofs.EroFS(f)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fs.WalkDir(img, "/", func(path string, entry fs.DirEntry, err error) error {
-		fmt.Println(path)
-		return nil
-	})
+```go
+f, err := os.Open("image.erofs")
+if err != nil {
+    log.Fatal(err)
 }
+defer f.Close()
+
+img, err := erofs.Open(f)
+if err != nil {
+    log.Fatal(err)
+}
+
+fs.WalkDir(img, ".", func(path string, d fs.DirEntry, err error) error {
+    fmt.Println(path)
+    return nil
+})
+```
+
+## Merging multiple layers
+
+Combine multiple filesystem sources into one image. The `Merge` option enables overlay semantics — AUFS-style whiteout files (`.wh.<name>`) delete entries from prior layers:
+
+```go
+outFile, _ := os.Create("merged.erofs")
+w := erofs.Create(outFile)
+
+w.CopyFrom(baseLayer)
+w.CopyFrom(overlayLayer, erofs.Merge())
+w.Close()
+```
+
+Merge can also be combined with `MetadataOnly` to build a merged index without copying data:
+
+```go
+w := erofs.Create(outFile)
+w.CopyFrom(layer1, erofs.MetadataOnly())
+w.CopyFrom(layer2, erofs.MetadataOnly(), erofs.Merge())
+w.Close()
+```
+
+## Building an image programmatically
+
+```go
+outFile, _ := os.Create("image.erofs")
+w := erofs.Create(outFile)
+
+f, _ := w.Create("/hello.txt")
+f.Write([]byte("hello world\n"))
+f.Close()
+
+w.Mkdir("/dir", 0o755)
+w.Symlink("hello.txt", "/link")
+
+w.Close()
+outFile.Close()
 ```

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,842 @@
+package erofs_test
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"testing"
+	"time"
+
+	erofs "github.com/erofs/go-erofs"
+)
+
+const benchTargetSize = 250 * 1024 * 1024
+
+// benchMergeOverlayFraction controls what fraction of the base layer the
+// overlay replaces.  1/8 means ~31 MB of overlay on a 250 MB base.
+const benchMergeOverlayFraction = 8
+
+// populateBenchDir creates a realistic container-layer directory tree with
+// many small config files, medium libraries, large binaries, symlinks, and
+// docs totaling roughly targetSize bytes of file content.
+func populateBenchDir(b *testing.B, root string, targetSize int64) {
+	b.Helper()
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	written := int64(0)
+
+	writeFile := func(name string, size int, mode os.FileMode) {
+		p := filepath.Join(root, filepath.FromSlash(name))
+		_ = os.MkdirAll(filepath.Dir(p), 0755)
+		data := make([]byte, size)
+		for i := range data {
+			data[i] = byte(i % 251)
+		}
+		if err := os.WriteFile(p, data, mode); err != nil {
+			b.Fatal(err)
+		}
+		_ = os.Chtimes(p, now, now)
+		written += int64(size)
+	}
+
+	writeDir := func(name string) {
+		p := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(p, 0755); err != nil {
+			b.Fatal(err)
+		}
+		_ = os.Chtimes(p, now, now)
+	}
+
+	writeSymlink := func(name, target string) {
+		p := filepath.Join(root, filepath.FromSlash(name))
+		_ = os.MkdirAll(filepath.Dir(p), 0755)
+		if err := os.Symlink(target, p); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	for _, d := range []string{
+		"/usr", "/usr/bin", "/usr/lib", "/usr/lib/x86_64-linux-gnu",
+		"/usr/share", "/usr/share/doc", "/usr/share/man",
+		"/etc", "/etc/apt", "/var", "/var/lib", "/var/cache",
+	} {
+		writeDir(d)
+	}
+
+	for i := 0; written < targetSize/4 && i < 2000; i++ {
+		size := 100 + (i*137)%1900
+		writeFile(fmt.Sprintf("/etc/conf.d/config-%04d", i), size, 0644)
+	}
+
+	for i := 0; written < targetSize*3/4; i++ {
+		size := 50*1024 + (i*7919)%(450*1024)
+		writeFile(fmt.Sprintf("/usr/lib/x86_64-linux-gnu/lib%04d.so", i), size, 0755)
+	}
+
+	for i := 0; written < targetSize; i++ {
+		remaining := targetSize - written
+		size := min(int64(2*1024*1024), remaining)
+		writeFile(fmt.Sprintf("/usr/bin/binary-%04d", i), int(size), 0755)
+	}
+
+	for i := range 50 {
+		writeSymlink(
+			fmt.Sprintf("/usr/lib/x86_64-linux-gnu/lib%04d.so.1", i),
+			fmt.Sprintf("lib%04d.so", i),
+		)
+	}
+
+	for i := range 500 {
+		size := 200 + (i*31)%800
+		writeFile(fmt.Sprintf("/usr/share/doc/package-%04d/README", i), size, 0644)
+	}
+}
+
+// populateOverlayDir creates a directory that acts as an overlay on top of
+// a base layer produced by populateBenchDir. It overwrites some files,
+// deletes others via whiteouts, and adds new entries.
+func populateOverlayDir(b *testing.B, root string, targetSize int64) {
+	b.Helper()
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	written := int64(0)
+
+	writeFile := func(name string, size int, mode os.FileMode) {
+		p := filepath.Join(root, filepath.FromSlash(name))
+		_ = os.MkdirAll(filepath.Dir(p), 0755)
+		data := make([]byte, size)
+		for i := range data {
+			data[i] = byte((i + 7) % 251)
+		}
+		if err := os.WriteFile(p, data, mode); err != nil {
+			b.Fatal(err)
+		}
+		_ = os.Chtimes(p, now, now)
+		written += int64(size)
+	}
+
+	writeDir := func(name string) {
+		p := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(p, 0755); err != nil {
+			b.Fatal(err)
+		}
+		_ = os.Chtimes(p, now, now)
+	}
+
+	writeWhiteout := func(name string) {
+		p := filepath.Join(root, filepath.FromSlash(name))
+		_ = os.MkdirAll(filepath.Dir(p), 0755)
+		if err := os.WriteFile(p, nil, 0644); err != nil {
+			b.Fatal(err)
+		}
+		_ = os.Chtimes(p, now, now)
+	}
+
+	// Whiteouts: delete some config files and a library.
+	for _, wh := range []string{
+		"/etc/conf.d/.wh.config-0050",
+		"/etc/conf.d/.wh.config-0051",
+		"/etc/conf.d/.wh.config-0052",
+		"/usr/lib/x86_64-linux-gnu/.wh.lib0010.so",
+	} {
+		writeWhiteout(wh)
+	}
+
+	// Opaque directory: replace all docs.
+	writeDir("/usr/share/doc/")
+	writeWhiteout("/usr/share/doc/.wh..wh..opq")
+
+	// Overwrite some configs.
+	for i := range 20 {
+		size := 200 + (i*137)%1900
+		writeFile(fmt.Sprintf("/etc/conf.d/config-%04d", i), size, 0644)
+	}
+
+	// New directory tree.
+	writeDir("/opt/")
+	writeDir("/opt/overlay/")
+
+	// Fill to target size with new files.
+	for i := 0; written < targetSize; i++ {
+		remaining := targetSize - written
+		size := min(int64(512*1024), remaining)
+		if size <= 0 {
+			break
+		}
+		writeFile(fmt.Sprintf("/opt/overlay/data-%04d.bin", i), int(size), 0644)
+	}
+}
+
+// prepareBenchDir builds a realistic directory tree for benchmarks.
+func prepareBenchDir(b *testing.B) string {
+	b.Helper()
+	dirPath := filepath.Join(b.TempDir(), "root")
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		b.Fatal(err)
+	}
+	populateBenchDir(b, dirPath, benchTargetSize)
+	return dirPath
+}
+
+// newDirFS wraps os.DirFS with Lstat-based Stat and ReadLink support.
+type benchDirFS struct {
+	root string
+}
+
+func (d *benchDirFS) Open(name string) (fs.File, error) {
+	return os.DirFS(d.root).Open(name)
+}
+
+func (d *benchDirFS) Stat(name string) (fs.FileInfo, error) {
+	return os.Lstat(filepath.Join(d.root, filepath.FromSlash(name)))
+}
+
+func (d *benchDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return os.ReadDir(filepath.Join(d.root, filepath.FromSlash(name)))
+}
+
+func (d *benchDirFS) ReadLink(name string) (string, error) {
+	return os.Readlink(filepath.Join(d.root, filepath.FromSlash(name)))
+}
+
+// disableGC disables automatic GC for accurate benchmarking and returns
+// a cleanup function that re-enables it. Between iterations, call the
+// returned gc function with the timer stopped to reclaim memory without
+// polluting measurements.
+func disableGC(b *testing.B) (gc func()) {
+	b.Helper()
+	prev := debug.SetGCPercent(-1)
+	runtime.GC()
+	b.Cleanup(func() { debug.SetGCPercent(prev) })
+	return func() {
+		b.StopTimer()
+		runtime.GC()
+		b.StartTimer()
+	}
+}
+
+func BenchmarkDir(b *testing.B) {
+	dirPath := prepareBenchDir(b)
+
+	b.Run("go", func(b *testing.B) {
+		gc := disableGC(b)
+		b.ReportAllocs()
+		for range b.N {
+			gc()
+			outPath := filepath.Join(b.TempDir(), "out.erofs")
+			outFile, err := os.Create(outPath)
+			if err != nil {
+				b.Fatal(err)
+			}
+			w := erofs.Create(outFile)
+			if err := w.CopyFrom(&benchDirFS{root: dirPath}); err != nil {
+				_ = outFile.Close()
+				b.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				_ = outFile.Close()
+				b.Fatal(err)
+			}
+			_ = outFile.Close()
+			_ = os.Remove(outPath)
+		}
+	})
+
+	b.Run("mkfs.erofs", func(b *testing.B) {
+		if _, err := exec.LookPath("mkfs.erofs"); err != nil {
+			b.Skip("mkfs.erofs not available")
+		}
+		b.ReportAllocs()
+		for range b.N {
+			outPath := filepath.Join(b.TempDir(), "out.erofs")
+			cmd := exec.Command("mkfs.erofs", "-Enoinline_data", "--quiet", outPath, dirPath)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				b.Fatalf("mkfs.erofs: %v\n%s", err, out)
+			}
+			_ = os.Remove(outPath)
+		}
+	})
+}
+
+// buildErofsFromDir creates an EROFS image from a directory.
+func buildErofsFromDir(b *testing.B, dirPath, outPath string, opts ...erofs.CopyOpt) {
+	b.Helper()
+	outFile, err := os.Create(outPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer outFile.Close() //nolint:errcheck
+	w := erofs.Create(outFile)
+	if err := w.CopyFrom(&benchDirFS{root: dirPath}, opts...); err != nil {
+		b.Fatal("build erofs from dir:", err)
+	}
+	if err := w.Close(); err != nil {
+		b.Fatal("close erofs:", err)
+	}
+}
+
+// mergeSources holds paths for merge benchmark inputs.
+type mergeSources struct {
+	// Full EROFS images (with data) for erofs-to-erofs merge benchmarks.
+	goBaseFullPath    string // base layer full EROFS (go-erofs)
+	goOverlayFullPath string // overlay layer full EROFS (go-erofs)
+
+	// mkfs.erofs-built full EROFS images.
+	mkfsBaseFullPath    string
+	mkfsOverlayFullPath string
+
+	// Overlay directory for go/merge benchmark.
+	overlayDirPath string
+}
+
+// prepareMergeSources builds a base directory, overlay directory, and EROFS
+// images for merge benchmarks.
+func prepareMergeSources(b *testing.B) mergeSources {
+	b.Helper()
+	tmpDir := b.TempDir()
+
+	var s mergeSources
+
+	// Build base directory.
+	baseDirPath := filepath.Join(tmpDir, "base")
+	if err := os.MkdirAll(baseDirPath, 0755); err != nil {
+		b.Fatal(err)
+	}
+	populateBenchDir(b, baseDirPath, benchTargetSize)
+
+	// Build overlay directory.
+	s.overlayDirPath = filepath.Join(tmpDir, "overlay")
+	if err := os.MkdirAll(s.overlayDirPath, 0755); err != nil {
+		b.Fatal(err)
+	}
+	populateOverlayDir(b, s.overlayDirPath, benchTargetSize/benchMergeOverlayFraction)
+
+	// Build full EROFS images (Go) for erofs-to-erofs merge benchmarks.
+	s.goBaseFullPath = filepath.Join(tmpDir, "base-full-go.erofs")
+	buildErofsFromDir(b, baseDirPath, s.goBaseFullPath)
+	fi, _ := os.Stat(s.goBaseFullPath)
+	b.Logf("base erofs full (go): %.1f MB", float64(fi.Size())/(1024*1024))
+
+	s.goOverlayFullPath = filepath.Join(tmpDir, "overlay-full-go.erofs")
+	buildErofsFromDir(b, s.overlayDirPath, s.goOverlayFullPath)
+	fi, _ = os.Stat(s.goOverlayFullPath)
+	b.Logf("overlay erofs full (go): %.1f MB", float64(fi.Size())/(1024*1024))
+
+	// Build full EROFS images (mkfs.erofs) for erofs-to-erofs merge benchmarks.
+	if _, err := exec.LookPath("mkfs.erofs"); err == nil {
+		for _, tc := range []struct {
+			dirPath string
+			field   *string
+			label   string
+		}{
+			{baseDirPath, &s.mkfsBaseFullPath, "base"},
+			{s.overlayDirPath, &s.mkfsOverlayFullPath, "overlay"},
+		} {
+			outPath := filepath.Join(tmpDir, tc.label+"-full-mkfs.erofs")
+			cmd := exec.Command("mkfs.erofs", "-Enoinline_data", "--quiet", outPath, tc.dirPath)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				b.Fatalf("mkfs.erofs %s: %v\n%s", tc.label, err, out)
+			}
+			*tc.field = outPath
+			fi, _ = os.Stat(outPath)
+			b.Logf("%s erofs full (mkfs): %.1f MB", tc.label, float64(fi.Size())/(1024*1024))
+		}
+	}
+
+	return s
+}
+
+// BenchmarkMerge measures the cost of merging an overlay on top of a
+// metadata-only base layer.
+//
+// Sub-benchmarks:
+//
+//	go/merge           — MetadataOnly(base) + Merge(overlay dir) → EROFS
+//	go/erofs           — merge two full EROFS images
+//	go/erofs-meta      — merge two full EROFS images as metadata-only
+//	mkfs.erofs/erofs   — mkfs.erofs merge: two full EROFS images
+func BenchmarkMerge(b *testing.B) {
+	src := prepareMergeSources(b)
+
+	// go/merge: full EROFS base + Merge overlay dir.
+	b.Run("go/merge", func(b *testing.B) {
+		gc := disableGC(b)
+		b.ReportAllocs()
+		for range b.N {
+			gc()
+			baseErofsFile, err := os.Open(src.goBaseFullPath)
+			if err != nil {
+				b.Fatal(err)
+			}
+			baseFS, err := erofs.Open(baseErofsFile)
+			if err != nil {
+				_ = baseErofsFile.Close()
+				b.Fatal(err)
+			}
+
+			outPath := filepath.Join(b.TempDir(), "out.erofs")
+			outFile, err := os.Create(outPath)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			w := erofs.Create(outFile)
+			if err := w.CopyFrom(baseFS); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.CopyFrom(&benchDirFS{root: src.overlayDirPath}, erofs.Merge()); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				b.Fatal(err)
+			}
+
+			_ = outFile.Close()
+			_ = baseErofsFile.Close()
+			_ = os.Remove(outPath)
+		}
+	})
+
+	// go/erofs: merge two full EROFS images (base + overlay).
+	b.Run("go/erofs", func(b *testing.B) {
+		gc := disableGC(b)
+		b.ReportAllocs()
+		for range b.N {
+			gc()
+			baseFile, err := os.Open(src.goBaseFullPath)
+			if err != nil {
+				b.Fatal(err)
+			}
+			baseFS, err := erofs.Open(baseFile)
+			if err != nil {
+				_ = baseFile.Close()
+				b.Fatal(err)
+			}
+			overlayFile, err := os.Open(src.goOverlayFullPath)
+			if err != nil {
+				_ = baseFile.Close()
+				b.Fatal(err)
+			}
+			overlayFS, err := erofs.Open(overlayFile)
+			if err != nil {
+				_ = baseFile.Close()
+				_ = overlayFile.Close()
+				b.Fatal(err)
+			}
+
+			outPath := filepath.Join(b.TempDir(), "out.erofs")
+			outFile, err := os.Create(outPath)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			w := erofs.Create(outFile)
+			if err := w.CopyFrom(baseFS); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.CopyFrom(overlayFS, erofs.Merge()); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				b.Fatal(err)
+			}
+
+			_ = outFile.Close()
+			_ = baseFile.Close()
+			_ = overlayFile.Close()
+			_ = os.Remove(outPath)
+		}
+	})
+
+	// go/erofs-meta: merge two full EROFS images as metadata-only
+	// (snapshotter index pattern — no data copied, only metadata + chunk refs).
+	b.Run("go/erofs-meta", func(b *testing.B) {
+		gc := disableGC(b)
+		b.ReportAllocs()
+		for range b.N {
+			gc()
+			baseFile, err := os.Open(src.goBaseFullPath)
+			if err != nil {
+				b.Fatal(err)
+			}
+			baseFS, err := erofs.Open(baseFile)
+			if err != nil {
+				_ = baseFile.Close()
+				b.Fatal(err)
+			}
+			overlayFile, err := os.Open(src.goOverlayFullPath)
+			if err != nil {
+				_ = baseFile.Close()
+				b.Fatal(err)
+			}
+			overlayFS, err := erofs.Open(overlayFile)
+			if err != nil {
+				_ = baseFile.Close()
+				_ = overlayFile.Close()
+				b.Fatal(err)
+			}
+
+			outPath := filepath.Join(b.TempDir(), "out.erofs")
+			outFile, err := os.Create(outPath)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			w := erofs.Create(outFile)
+			if err := w.CopyFrom(baseFS, erofs.MetadataOnly()); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.CopyFrom(overlayFS, erofs.MetadataOnly(), erofs.Merge()); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				b.Fatal(err)
+			}
+
+			_ = outFile.Close()
+			_ = baseFile.Close()
+			_ = overlayFile.Close()
+			_ = os.Remove(outPath)
+		}
+	})
+
+	// mkfs.erofs/erofs: merge two full EROFS images via mkfs.erofs.
+	b.Run("mkfs.erofs/erofs", func(b *testing.B) {
+		if src.mkfsBaseFullPath == "" {
+			b.Skip("mkfs.erofs not available")
+		}
+		b.ReportAllocs()
+		for range b.N {
+			outPath := filepath.Join(b.TempDir(), "out.erofs")
+			cmd := exec.Command("mkfs.erofs",
+				"--aufs", "--ovlfs-strip=1", "--quiet", "-Enoinline_data",
+				outPath, src.mkfsBaseFullPath, src.mkfsOverlayFullPath)
+			out, err := cmd.CombinedOutput()
+			_ = os.Remove(outPath)
+			if err != nil {
+				b.Fatalf("mkfs.erofs erofs merge: %v\n%s", err, out)
+			}
+		}
+	})
+}
+
+// layerSpec describes a container image layer for the 10-layer benchmark.
+type layerSpec struct {
+	name      string
+	size      int64    // approximate target size
+	whiteouts []string // .wh.<name> entries
+	opaques   []string // directories to make opaque
+}
+
+// BenchmarkMerge10Layer simulates a realistic container image with 10 layers:
+//
+//	Layer 0: base OS (~250 MB)
+//	Layers 1-9: progressively smaller, some with whiteouts/opaques
+//
+// Each layer is a full EROFS image. The benchmark merges all 10 into a single
+// metadata-only index with 10 blob devices.
+func BenchmarkMerge10Layer(b *testing.B) {
+	layers := []layerSpec{
+		{name: "base-os", size: 250 * 1024 * 1024},
+		{name: "runtime", size: 30 * 1024 * 1024},
+		{name: "deps", size: 15 * 1024 * 1024,
+			whiteouts: []string{"/usr/share/doc/.wh..wh..opq"}},
+		{name: "app-v1", size: 8 * 1024 * 1024},
+		{name: "app-v2", size: 5 * 1024 * 1024,
+			whiteouts: []string{"/opt/app/.wh.old-binary"},
+			opaques:   []string{"/tmp/"}},
+		{name: "config", size: 50 * 1024},
+		{name: "secrets", size: 4 * 1024},
+		{name: "hotfix1", size: 2 * 1024 * 1024,
+			whiteouts: []string{"/usr/lib/x86_64-linux-gnu/.wh.libold.so"}},
+		{name: "hotfix2", size: 500 * 1024},
+		{name: "metadata", size: 10 * 1024},
+	}
+
+	tmpDir := b.TempDir()
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Build dir + EROFS for each layer.
+	type layerFiles struct {
+		goErofsPath   string
+		mkfsErofsPath string
+	}
+	built := make([]layerFiles, len(layers))
+
+	for li, spec := range layers {
+		// Generate directory.
+		dirPath := filepath.Join(tmpDir, fmt.Sprintf("layer%d", li))
+		if err := os.MkdirAll(dirPath, 0755); err != nil {
+			b.Fatal(err)
+		}
+
+		func() {
+			written := int64(0)
+
+			writeDir := func(name string) {
+				p := filepath.Join(dirPath, filepath.FromSlash(name))
+				_ = os.MkdirAll(p, 0755)
+				_ = os.Chtimes(p, now, now)
+			}
+			writeFile := func(name string, size int) {
+				p := filepath.Join(dirPath, filepath.FromSlash(name))
+				_ = os.MkdirAll(filepath.Dir(p), 0755)
+				data := make([]byte, size)
+				for i := range data {
+					data[i] = byte((i + li*7) % 251)
+				}
+				_ = os.WriteFile(p, data, 0644)
+				_ = os.Chtimes(p, now, now)
+				written += int64(size)
+			}
+			writeWhiteout := func(name string) {
+				p := filepath.Join(dirPath, filepath.FromSlash(name))
+				_ = os.MkdirAll(filepath.Dir(p), 0755)
+				_ = os.WriteFile(p, nil, 0644)
+				_ = os.Chtimes(p, now, now)
+			}
+
+			// Whiteouts first (before dirs they reference).
+			for _, wh := range spec.whiteouts {
+				writeWhiteout(wh)
+			}
+			for _, op := range spec.opaques {
+				writeDir(op)
+				writeWhiteout(op + ".wh..wh..opq")
+			}
+
+			if li == 0 {
+				// Base OS layer: realistic tree with 5000+ files at various depths.
+				dirs := []string{
+					"/", "/bin", "/sbin", "/lib", "/lib/x86_64-linux-gnu",
+					"/lib/x86_64-linux-gnu/security",
+					"/usr", "/usr/bin", "/usr/sbin", "/usr/lib",
+					"/usr/lib/x86_64-linux-gnu",
+					"/usr/lib/python3", "/usr/lib/python3/dist-packages",
+					"/usr/lib/python3/dist-packages/pip",
+					"/usr/lib/python3/dist-packages/pip/internal",
+					"/usr/lib/python3/dist-packages/setuptools",
+					"/usr/share", "/usr/share/doc", "/usr/share/man",
+					"/usr/share/man/man1", "/usr/share/man/man5", "/usr/share/man/man8",
+					"/usr/share/locale", "/usr/share/locale/en", "/usr/share/locale/de",
+					"/usr/share/zoneinfo", "/usr/share/zoneinfo/US",
+					"/usr/share/zoneinfo/Europe",
+					"/usr/include", "/usr/include/linux", "/usr/include/x86_64-linux-gnu",
+					"/etc", "/etc/apt", "/etc/apt/sources.list.d",
+					"/etc/default", "/etc/init.d", "/etc/cron.d",
+					"/etc/ssl", "/etc/ssl/certs",
+					"/etc/systemd", "/etc/systemd/system",
+					"/var", "/var/lib", "/var/lib/apt", "/var/lib/dpkg",
+					"/var/lib/dpkg/info", "/var/cache", "/var/cache/apt",
+					"/var/log", "/var/tmp",
+					"/opt", "/opt/app", "/tmp", "/run",
+				}
+				for _, d := range dirs {
+					writeDir(d)
+				}
+
+				// ~2000 small config/metadata files (50-2000 bytes)
+				for i := 0; i < 800 && written < spec.size/8; i++ {
+					sz := 100 + (i*137)%1900
+					writeFile(fmt.Sprintf("/etc/apt/sources.list.d/source-%04d.list", i), sz)
+				}
+				for i := 0; i < 600 && written < spec.size/5; i++ {
+					sz := 50 + (i*31)%500
+					writeFile(fmt.Sprintf("/var/lib/dpkg/info/pkg-%04d.md5sums", i), sz)
+				}
+				for i := 0; i < 600 && written < spec.size*3/10; i++ {
+					sz := 200 + (i*41)%1800
+					writeFile(fmt.Sprintf("/usr/share/doc/package-%04d/README", i), sz)
+				}
+
+				// ~1000 medium Python/locale files (1-20 KB)
+				for i := 0; i < 400 && written < spec.size*2/5; i++ {
+					sz := 1024 + (i*997)%(19*1024)
+					writeFile(fmt.Sprintf("/usr/lib/python3/dist-packages/pip/internal/mod_%04d.py", i), sz)
+				}
+				for i := 0; i < 300 && written < spec.size/2; i++ {
+					sz := 2048 + (i*773)%(18*1024)
+					writeFile(fmt.Sprintf("/usr/lib/python3/dist-packages/setuptools/cmd_%04d.py", i), sz)
+				}
+				for i := 0; i < 200 && written < spec.size*11/20; i++ {
+					sz := 500 + (i*251)%(4*1024)
+					writeFile(fmt.Sprintf("/usr/include/linux/header_%04d.h", i), sz)
+				}
+				for i := 0; i < 50; i++ {
+					sz := 5*1024 + (i*3571)%(45*1024)
+					writeFile(fmt.Sprintf("/usr/share/locale/en/messages_%04d.mo", i), sz)
+					writeFile(fmt.Sprintf("/usr/share/locale/de/messages_%04d.mo", i), sz)
+				}
+				for i := 0; i < 300 && written < spec.size*13/20; i++ {
+					sz := 100 + (i*59)%900
+					writeFile(fmt.Sprintf("/usr/share/man/man1/cmd_%04d.1", i), sz)
+				}
+				for i := 0; i < 200 && written < spec.size*3/4; i++ {
+					sz := 200 + (i*67)%1200
+					writeFile(fmt.Sprintf("/etc/ssl/certs/cert_%04d.pem", i), sz)
+				}
+
+				// ~200 shared libraries (50-500 KB)
+				for i := 0; i < 200 && written < spec.size*17/20; i++ {
+					sz := 50*1024 + (i*7919)%(450*1024)
+					writeFile(fmt.Sprintf("/usr/lib/x86_64-linux-gnu/lib%04d.so", i), sz)
+				}
+
+				// ~50 security/PAM modules (10-100 KB)
+				for i := 0; i < 50; i++ {
+					sz := 10*1024 + (i*1009)%(90*1024)
+					writeFile(fmt.Sprintf("/lib/x86_64-linux-gnu/security/pam_%04d.so", i), sz)
+				}
+
+				// ~100 timezone files (200 bytes - 2 KB)
+				for i := 0; i < 50; i++ {
+					sz := 200 + (i*127)%1800
+					writeFile(fmt.Sprintf("/usr/share/zoneinfo/US/zone_%04d", i), sz)
+					writeFile(fmt.Sprintf("/usr/share/zoneinfo/Europe/zone_%04d", i), sz)
+				}
+
+				// Additional small files to ensure 5000+ total.
+				for i := 0; i < 500; i++ {
+					sz := 64 + (i*37)%400
+					writeFile(fmt.Sprintf("/var/lib/apt/lists/pkg_%04d", i), sz)
+				}
+				for i := 0; i < 300; i++ {
+					sz := 100 + (i*53)%600
+					writeFile(fmt.Sprintf("/etc/cron.d/job_%04d", i), sz)
+				}
+
+				// Large binaries to fill remaining.
+				for i := 0; written < spec.size; i++ {
+					remaining := spec.size - written
+					sz := min(int64(2*1024*1024), remaining)
+					if sz < 1 {
+						break
+					}
+					writeFile(fmt.Sprintf("/usr/bin/binary-%04d", i), int(sz))
+				}
+			} else {
+				// Upper layers: simpler structure.
+				for _, d := range []string{"/", "/usr", "/usr/lib", "/usr/lib/x86_64-linux-gnu",
+					"/usr/share", "/usr/share/doc", "/opt", "/opt/app", "/tmp", "/etc"} {
+					writeDir(d)
+				}
+				for i := 0; written < spec.size; i++ {
+					remaining := spec.size - written
+					sz := min(int64(512*1024), remaining)
+					if sz < 1 {
+						break
+					}
+					writeFile(fmt.Sprintf("/opt/app/%s-%04d.bin", spec.name, i), int(sz))
+				}
+			}
+		}()
+
+		// Build Go EROFS.
+		goPath := filepath.Join(tmpDir, fmt.Sprintf("layer%d-go.erofs", li))
+		buildErofsFromDir(b, dirPath, goPath)
+		built[li].goErofsPath = goPath
+
+		// Build mkfs.erofs EROFS.
+		if _, err := exec.LookPath("mkfs.erofs"); err == nil {
+			mkfsPath := filepath.Join(tmpDir, fmt.Sprintf("layer%d-mkfs.erofs", li))
+			cmd := exec.Command("mkfs.erofs", "-Enoinline_data", "--quiet", mkfsPath, dirPath)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				b.Fatalf("mkfs.erofs layer %d: %v\n%s", li, err, out)
+			}
+			built[li].mkfsErofsPath = mkfsPath
+		}
+
+		fi, _ := os.Stat(goPath)
+		// Count inodes by opening the image.
+		inodes := uint64(0)
+		if gf, err := os.Open(goPath); err == nil {
+			if efs, err := erofs.Open(gf); err == nil {
+				_ = fs.WalkDir(efs, ".", func(_ string, _ fs.DirEntry, _ error) error {
+					inodes++
+					return nil
+				})
+			}
+			_ = gf.Close()
+		}
+		b.Logf("layer %d (%s): target %s, erofs %.1f MB, %d files",
+			li, spec.name, formatSize(spec.size), float64(fi.Size())/(1024*1024), inodes)
+	}
+
+	// go: merge all 10 layers as MetadataOnly into a single index.
+	b.Run("go", func(b *testing.B) {
+		gc := disableGC(b)
+		b.ReportAllocs()
+		for range b.N {
+			gc()
+			var files []*os.File
+			outPath := filepath.Join(b.TempDir(), "merged.erofs")
+			outFile, err := os.Create(outPath)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			w := erofs.Create(outFile)
+			for li, lf := range built {
+				f, err := os.Open(lf.goErofsPath)
+				if err != nil {
+					b.Fatal(err)
+				}
+				files = append(files, f)
+				efs, err := erofs.Open(f)
+				if err != nil {
+					b.Fatal(err)
+				}
+				opts := []erofs.CopyOpt{erofs.MetadataOnly()}
+				if li > 0 {
+					opts = append(opts, erofs.Merge())
+				}
+				if err := w.CopyFrom(efs, opts...); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if err := w.Close(); err != nil {
+				b.Fatal(err)
+			}
+
+			_ = outFile.Close()
+			for _, f := range files {
+				_ = f.Close()
+			}
+			_ = os.Remove(outPath)
+		}
+	})
+
+	// mkfs.erofs: merge all 10 layers.
+	b.Run("mkfs.erofs", func(b *testing.B) {
+		if built[0].mkfsErofsPath == "" {
+			b.Skip("mkfs.erofs not available")
+		}
+		b.ReportAllocs()
+		for range b.N {
+			outPath := filepath.Join(b.TempDir(), "merged.erofs")
+			args := []string{"--aufs", "--ovlfs-strip=1", "--quiet", "-Enoinline_data", outPath}
+			for _, lf := range built {
+				args = append(args, lf.mkfsErofsPath)
+			}
+			cmd := exec.Command("mkfs.erofs", args...)
+			out, err := cmd.CombinedOutput()
+			_ = os.Remove(outPath)
+			if err != nil {
+				b.Fatalf("mkfs.erofs: %v\n%s", err, out)
+			}
+		}
+	})
+}
+
+func formatSize(b int64) string {
+	switch {
+	case b >= 1024*1024:
+		return fmt.Sprintf("%.0f MB", float64(b)/(1024*1024))
+	case b >= 1024:
+		return fmt.Sprintf("%.0f KB", float64(b)/1024)
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/erofs.go
+++ b/erofs.go
@@ -1,3 +1,28 @@
+// Package erofs reads and creates EROFS filesystem images.
+//
+// # Reading
+//
+// Use [Open] to read an existing EROFS image through Go's standard [fs.FS]
+// interface:
+//
+//	img, err := erofs.Open(f)
+//	data, err := fs.ReadFile(img, "etc/hostname")
+//
+// # Writing
+//
+// Use [Create] to build a new EROFS image. Entries can be added one at a
+// time, or bulk-copied from any [fs.FS] via [Writer.CopyFrom]:
+//
+//	w := erofs.Create(outFile)
+//	w.CopyFrom(srcFS)
+//	w.Close()
+//
+// For metadata-only images that reference data in an external source
+// (e.g. for container layer indexing), pass [MetadataOnly] to CopyFrom:
+//
+//	w := erofs.Create(outFile)
+//	w.CopyFrom(srcFS, erofs.MetadataOnly())
+//	w.Close()
 package erofs
 
 import (
@@ -249,6 +274,108 @@ func (img *image) mapDev(deviceID uint16, pa int64) (io.ReaderAt, int64, error) 
 	}
 
 	return img.meta, pa, nil
+}
+
+// blockSize returns the filesystem block size.
+func (img *image) blockSize() uint32 { return 1 << img.sb.BlkSizeBits }
+
+// buildTime returns the build timestamp from the superblock.
+func (img *image) buildTime() uint64 { return img.sb.BuildTime }
+
+// deviceBlocks returns the total block count across all extra devices.
+// Each device's block count is reported at the device's native block size
+// (matching the superblock block size).
+func (img *image) deviceBlocks() []uint64 {
+	if len(img.devices) == 0 {
+		return nil
+	}
+	blocks := make([]uint64, len(img.devices))
+	for i, d := range img.devices {
+		blocks[i] = uint64(d.blocks)
+	}
+	return blocks
+}
+
+// openDirect returns an io.Reader for a file's data that reads directly
+// from the underlying metadata reader, bypassing the block-at-a-time
+// Read path. Returns nil if direct reading is not possible (e.g.
+// chunk-based or compressed files).
+func (img *image) openDirect(ino *inode) io.Reader {
+	if ino.size <= 0 {
+		return nil
+	}
+	blockSize := int64(1 << img.sb.BlkSizeBits)
+	switch ino.inodeLayout {
+	case disk.LayoutFlatPlain:
+		// Data is contiguous starting at dataBlkAddr.
+		dataOffset := int64(ino.inodeData) << img.sb.BlkSizeBits
+		return io.NewSectionReader(img.meta, dataOffset, ino.size)
+	case disk.LayoutFlatInline:
+		// Last block is inline after the inode; earlier blocks at dataBlkAddr.
+		// Only use direct read for single-block files (all data inline).
+		if ino.size > blockSize {
+			return nil
+		}
+		inodeAddr := img.metaStartPos() + int64(ino.nid)*disk.SizeInodeCompact
+		trailingAddr := inodeAddr + ino.flatDataOffset()
+		return io.NewSectionReader(img.meta, trailingAddr, ino.size)
+	case disk.LayoutChunkBased:
+		// Chunk-based files store data at the physical block addresses
+		// listed in the chunk index. For contiguous single-device files,
+		// the data is laid out consecutively and can be read directly.
+		chunkFmt := uint16(ino.inodeData)
+		if chunkFmt&disk.LayoutChunkFormatIndexes == 0 {
+			return nil
+		}
+		chunkBits := img.sb.BlkSizeBits + uint8(chunkFmt&disk.LayoutChunkFormatBits)
+		nchunks := int((ino.size-1)>>chunkBits) + 1
+
+		// Read chunk index entries to check contiguity.
+		inodeStart := img.metaStartPos() + int64(ino.nid)*disk.SizeInodeCompact
+		baseOffset := inodeStart + ino.flatDataOffset()
+		if baseOffset%8 != 0 {
+			baseOffset = (baseOffset + 7) & ^int64(7)
+		}
+		needed := int64(nchunks * disk.SizeChunkIndex)
+		idxBuf := make([]byte, needed)
+		if _, err := img.meta.ReadAt(idxBuf, baseOffset); err != nil {
+			return nil
+		}
+
+		// Check that all chunks are contiguous on the same device.
+		var startBlock uint64
+		var deviceID uint16
+		for i := range nchunks {
+			off := i * disk.SizeChunkIndex
+			blkLo := binary.LittleEndian.Uint32(idxBuf[off+4 : off+8])
+			if ^blkLo == 0 {
+				return nil // hole
+			}
+			blkHi := binary.LittleEndian.Uint16(idxBuf[off : off+2])
+			did := binary.LittleEndian.Uint16(idxBuf[off+2:off+4]) & img.deviceIDMask
+			phys := (uint64(blkHi) << 32) | uint64(blkLo)
+
+			blocksPerChunk := uint64(1 << (chunkBits - img.sb.BlkSizeBits))
+			if i == 0 {
+				startBlock = phys
+				deviceID = did
+			} else {
+				expected := startBlock + uint64(i)*blocksPerChunk
+				if phys != expected || did != deviceID {
+					return nil // not contiguous or different device
+				}
+			}
+		}
+
+		// All chunks contiguous — resolve through the device.
+		dataOffset := int64(startBlock) << img.sb.BlkSizeBits
+		if deviceID > 0 && int(deviceID) <= len(img.devices) {
+			return io.NewSectionReader(img.devices[deviceID-1].device, dataOffset, ino.size)
+		}
+		return io.NewSectionReader(img.meta, dataOffset, ino.size)
+	default:
+		return nil
+	}
 }
 
 func (img *image) readMetadata(r io.Reader) ([]byte, error) {
@@ -1068,7 +1195,13 @@ func (d *dir) ReadDir(n int) ([]fs.DirEntry, error) {
 					d.img.putBlock(b)
 					return ents, fmt.Errorf("invalid dirent name offset %d (buf size %d): %w", dirents[0].NameOff, bufLen, ErrInvalid)
 				}
-				name = string(buf[dirents[0].NameOff:])
+				// The last entry name extends to end of block;
+				// trim any NUL padding.
+				raw := buf[dirents[0].NameOff:]
+				if j := bytes.IndexByte(raw, 0); j >= 0 {
+					raw = raw[:j]
+				}
+				name = string(raw)
 			}
 
 			if i >= d.consumed && name != "." && name != ".." {

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,70 @@
+package erofs_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+
+	erofs "github.com/erofs/go-erofs"
+)
+
+func ExampleOpen() {
+	f, err := os.Open("testdata/basic-default.erofs")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	img, err := erofs.Open(f)
+	if err != nil {
+		_ = f.Close()
+		log.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	_ = fs.WalkDir(img, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		fmt.Println(path)
+		return nil
+	})
+}
+
+func ExampleCreate() {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	f, err := w.Create("/hello.txt")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if _, err := f.Write([]byte("hello world\n")); err != nil {
+		log.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := w.Mkdir("/dir", 0o755); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := w.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Read back
+	img, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	data, err := fs.ReadFile(img, "hello.txt")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Print(string(data))
+	// Output: hello world
+}

--- a/format.go
+++ b/format.go
@@ -1,0 +1,137 @@
+package erofs
+
+import (
+	"io/fs"
+	"sort"
+	"strings"
+
+	"github.com/erofs/go-erofs/internal/disk"
+)
+
+// Standard xattr name prefix table (index → on-disk NameIndex).
+var xattrPrefixes = [...]struct {
+	index  uint8
+	prefix string
+}{
+	{1, "user."},
+	{2, "system.posix_acl_access."},
+	{3, "system.posix_acl_default."},
+	{4, "trusted."},
+	{5, "lustre."},
+	{6, "security."},
+}
+
+// xattrSplit splits a full xattr name into (NameIndex, suffix).
+func xattrSplit(name string) (uint8, string) {
+	for _, p := range xattrPrefixes {
+		if strings.HasPrefix(name, p.prefix) {
+			return p.index, name[len(p.prefix):]
+		}
+	}
+	return 0, name
+}
+
+// xattrEntrySize returns the on-disk size of a single xattr entry, padded to 4 bytes.
+func xattrEntrySize(name, value string) int {
+	_, suffix := xattrSplit(name)
+	sz := disk.SizeXattrEntry + len(suffix) + len(value)
+	if sz%4 != 0 {
+		sz = (sz + 3) & ^3
+	}
+	return sz
+}
+
+// calcXattrSize returns the total xattr area size (header + entries), or 0.
+func calcXattrSize(e *erofsEntry) int {
+	if len(e.xattrs) == 0 {
+		return 0
+	}
+	entriesSize := 0
+	for name, value := range e.xattrs {
+		entriesSize += xattrEntrySize(name, value)
+	}
+	return disk.SizeXattrBodyHeader + entriesSize
+}
+
+// xattrCount encodes the xattr area size into the inode XattrCount field.
+func xattrCount(xattrSize int) uint16 {
+	if xattrSize == 0 {
+		return 0
+	}
+	return uint16((xattrSize-disk.SizeXattrBodyHeader)/disk.SizeXattrEntry) + 1
+}
+
+// sortedXattrKeys returns xattr keys in deterministic order.
+func sortedXattrKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// inodeFormat builds the Format field: bit 0 = extended, bits 1-3 = layout.
+func inodeFormat(layout uint8, compact bool) uint16 {
+	f := uint16(layout) << 1
+	if !compact {
+		f |= 1 // bit 0 = extended
+	}
+	return f
+}
+
+// goModeToUnixMode converts Go fs.FileMode to Unix mode bits.
+func goModeToUnixMode(m fs.FileMode) uint16 {
+	mode := uint16(m.Perm())
+
+	if m&fs.ModeSetuid != 0 {
+		mode |= disk.StatTypeIsUID
+	}
+	if m&fs.ModeSetgid != 0 {
+		mode |= disk.StatTypeIsGID
+	}
+	if m&fs.ModeSticky != 0 {
+		mode |= disk.StatTypeIsVTX
+	}
+
+	switch m.Type() {
+	case 0: // regular file
+		mode |= disk.StatTypeReg
+	case fs.ModeDir:
+		mode |= disk.StatTypeDir
+	case fs.ModeSymlink:
+		mode |= disk.StatTypeSymlink
+	case fs.ModeDevice | fs.ModeCharDevice:
+		mode |= disk.StatTypeChrdev
+	case fs.ModeDevice:
+		mode |= disk.StatTypeBlkdev
+	case fs.ModeNamedPipe:
+		mode |= disk.StatTypeFifo
+	case fs.ModeSocket:
+		mode |= disk.StatTypeSock
+	}
+
+	return mode
+}
+
+// modeToFileType converts Unix mode bits to an EROFS file type.
+func modeToFileType(mode uint16) uint8 {
+	switch mode & disk.StatTypeMask {
+	case disk.StatTypeReg:
+		return disk.FileTypeReg
+	case disk.StatTypeDir:
+		return disk.FileTypeDir
+	case disk.StatTypeChrdev:
+		return disk.FileTypeChrdev
+	case disk.StatTypeBlkdev:
+		return disk.FileTypeBlkdev
+	case disk.StatTypeFifo:
+		return disk.FileTypeFifo
+	case disk.StatTypeSock:
+		return disk.FileTypeSock
+	case disk.StatTypeSymlink:
+		return disk.FileTypeSymlink
+	default:
+		return 0
+	}
+}

--- a/internal/builder/entry.go
+++ b/internal/builder/entry.go
@@ -1,0 +1,27 @@
+// Package builder provides shared types for the mkfs sub-packages.
+package builder
+
+import "io"
+
+// Entry carries extended metadata for a filesystem entry.
+// Mode and Size come from fs.FileInfo; everything else lives here.
+type Entry struct {
+	UID, GID     uint32
+	Mtime        uint64
+	MtimeNs      uint32
+	Nlink        uint32
+	Rdev         uint32
+	Xattrs       map[string]string
+	LinkTarget   string
+	Data         io.Reader // file content (full-image mode)
+	Chunks       []Chunk   // physical block refs (metadata-only mode)
+	Contiguous   bool      // data blocks are contiguous; flat-plain is sufficient
+	MetadataOnly bool      // chunk-based layout even without chunks
+}
+
+// Chunk maps a range of logical blocks to physical blocks on a device.
+type Chunk struct {
+	PhysicalBlock uint64 // physical block address
+	Count         uint16 // number of contiguous blocks
+	DeviceID      uint16 // 0 = primary, 1+ = extra device
+}

--- a/internal/disk/types.go
+++ b/internal/disk/types.go
@@ -20,6 +20,7 @@ const (
 	SizeXattrBodyHeader = 12
 	SizeXattrEntry      = 4
 	SizeDeviceSlot      = 128
+	SizeChunkIndex      = 8
 
 	LayoutFlatPlain         = 0
 	LayoutCompressedFull    = 1

--- a/internal/erofstest/fsck.go
+++ b/internal/erofstest/fsck.go
@@ -1,0 +1,79 @@
+package erofstest
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// FsckErofs runs fsck.erofs on the image at path. Skips if fsck.erofs
+// is not installed. Calls t.Error on validation failure.
+func FsckErofs(t testing.TB, path string) {
+	t.Helper()
+	if _, err := exec.LookPath("fsck.erofs"); err != nil {
+		return // silently skip
+	}
+	cmd := exec.Command("fsck.erofs", path)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Errorf("fsck.erofs %s failed: %v\n%s", path, err, out)
+	}
+}
+
+// FsckErofsBytes writes buf to a temp file, runs fsck.erofs, and cleans up.
+func FsckErofsBytes(t testing.TB, buf []byte) {
+	t.Helper()
+	if _, err := exec.LookPath("fsck.erofs"); err != nil {
+		return
+	}
+	f, err := os.CreateTemp(t.TempDir(), "fsck-*.erofs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(buf); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("fsck.erofs", f.Name())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Errorf("fsck.erofs failed: %v\n%s", err, out)
+	}
+}
+
+// FsckAvailable returns true if fsck.erofs is on PATH.
+func FsckAvailable() bool {
+	_, err := exec.LookPath("fsck.erofs")
+	return err == nil
+}
+
+// RequireFsck skips t if fsck.erofs is not available.
+func RequireFsck(t testing.TB) {
+	t.Helper()
+	if !FsckAvailable() {
+		t.Skip("fsck.erofs not available")
+	}
+}
+
+// FsckErofsDevice runs fsck.erofs with --device to validate metadata-only
+// images that reference external blob devices.
+func FsckErofsDevice(t testing.TB, imagePath string, devicePaths ...string) {
+	t.Helper()
+	if _, err := exec.LookPath("fsck.erofs"); err != nil {
+		return
+	}
+	args := []string{imagePath}
+	for _, d := range devicePaths {
+		args = append(args, fmt.Sprintf("--device=%s", d))
+	}
+	cmd := exec.Command("fsck.erofs", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Errorf("fsck.erofs %s failed: %v\n%s", imagePath, err, out)
+	}
+}

--- a/internal/erofstest/testbuf.go
+++ b/internal/erofstest/testbuf.go
@@ -1,0 +1,51 @@
+package erofstest
+
+import (
+	"fmt"
+	"io"
+)
+
+// TestBuffer is an in-memory io.WriteSeeker for tests.
+type TestBuffer struct {
+	buf []byte
+	pos int
+}
+
+func (b *TestBuffer) Write(p []byte) (int, error) {
+	end := b.pos + len(p)
+	if end > len(b.buf) {
+		if end > cap(b.buf) {
+			newBuf := make([]byte, end, end*2)
+			copy(newBuf, b.buf)
+			b.buf = newBuf
+		} else {
+			b.buf = b.buf[:end]
+		}
+	}
+	copy(b.buf[b.pos:], p)
+	b.pos = end
+	return len(p), nil
+}
+
+func (b *TestBuffer) Seek(offset int64, whence int) (int64, error) {
+	var abs int64
+	switch whence {
+	case io.SeekStart:
+		abs = offset
+	case io.SeekCurrent:
+		abs = int64(b.pos) + offset
+	case io.SeekEnd:
+		abs = int64(len(b.buf)) + offset
+	default:
+		return 0, fmt.Errorf("testbuf: invalid whence %d", whence)
+	}
+	if abs < 0 {
+		return 0, fmt.Errorf("testbuf: negative position %d", abs)
+	}
+	b.pos = int(abs)
+	return abs, nil
+}
+
+func (b *TestBuffer) Bytes() []byte {
+	return b.buf
+}

--- a/layout.go
+++ b/layout.go
@@ -1,0 +1,220 @@
+package erofs
+
+import (
+	"sort"
+
+	"github.com/erofs/go-erofs/internal/disk"
+)
+
+// planLayout assigns NIDs and determines trailing data sizes for all entries.
+func (w *erofsWriter) planLayout(root *erofsEntry) {
+	// Collect all entries in a deterministic order (DFS, pre-order).
+	// DFS keeps directory contents close to their parent inode,
+	// improving locality for operations like find and ls -lR.
+	w.entries = nil
+	var walk func(e *erofsEntry)
+	walk = func(e *erofsEntry) {
+		w.entries = append(w.entries, e)
+		if e.mode&disk.StatTypeMask == disk.StatTypeDir {
+			sort.Slice(e.children, func(i, j int) bool {
+				return e.children[i].name < e.children[j].name
+			})
+			for _, c := range e.children {
+				walk(c)
+			}
+		}
+	}
+	walk(root)
+
+	w.totalInodes = uint64(len(w.entries))
+
+	// Block 0 holds: 1024-byte pad + 128-byte superblock + device slot(s) + padding
+	// MetaBlkAddr is set later by write() depending on the on-disk layout.
+
+	// Assign NIDs sequentially.
+	// NID = byte offset from metaStartPos / 32.
+	// Each extended inode is 64 bytes = 2 NID slots.
+	// Trailing data follows and is padded to 32-byte boundary.
+	currentOff := 0 // byte offset from metaStartPos
+	for _, e := range w.entries {
+		e.nid = uint64(currentOff / 32)
+		e.xattrSize = calcXattrSize(e)
+
+		// Decide compact (32B) vs extended (64B) inode.
+		e.compact = e.uid <= 0xFFFF && e.gid <= 0xFFFF &&
+			e.nlink <= 0xFFFF && e.size <= 0xFFFFFFFF &&
+			e.mtime == w.buildTime && e.mtimeNs == 0
+
+		inodeSize := disk.SizeInodeExtended
+		if e.compact {
+			inodeSize = disk.SizeInodeCompact
+		}
+
+		// The inode header region is inode core + xattr area.
+		// Trailing data (dirents, chunk indexes, inline data) follows.
+		headerSize := inodeSize + e.xattrSize
+
+		// Determine layout
+		switch e.mode & disk.StatTypeMask {
+		case disk.StatTypeReg:
+			switch {
+			case e.size == 0 && len(e.chunks) == 0 && e.data == nil && !e.metadataOnly:
+				e.layout = disk.LayoutFlatPlain
+			case len(e.chunks) > 0 || e.metadataOnly:
+				e.layout = disk.LayoutChunkBased
+				if e.contiguous {
+					e.chunkBits = w.minChunkBits(e.size)
+				}
+			default:
+				// Full-image mode: decide inline vs plain
+				if int(e.size) <= w.blockSize-headerSize {
+					inBlockOff := (currentOff + headerSize) % w.blockSize
+					if inBlockOff+int(e.size) <= w.blockSize {
+						e.layout = disk.LayoutFlatInline
+					} else {
+						e.layout = disk.LayoutFlatPlain
+					}
+				} else {
+					e.layout = disk.LayoutFlatPlain
+				}
+			}
+		case disk.StatTypeDir:
+			direntDataSize := w.direntDataSize(e)
+			inBlockOff := (currentOff + headerSize) % w.blockSize
+			if direntDataSize > 0 && inBlockOff+direntDataSize <= w.blockSize {
+				e.layout = disk.LayoutFlatInline
+			} else {
+				e.layout = disk.LayoutFlatPlain
+			}
+		case disk.StatTypeSymlink:
+			inBlockOff := (currentOff + headerSize) % w.blockSize
+			if len(e.symTarget) > 0 && inBlockOff+len(e.symTarget) <= w.blockSize {
+				e.layout = disk.LayoutFlatInline
+			} else {
+				e.layout = disk.LayoutFlatPlain
+			}
+		default:
+			// Device files, fifos, sockets
+			e.layout = disk.LayoutFlatPlain
+		}
+
+		// Recalculate trailing size now that layout is decided
+		e.trailingSize = w.calcTrailingSize(e)
+
+		totalInodeSize := headerSize + e.trailingSize
+		// Pad to 32-byte boundary
+		if totalInodeSize%32 != 0 {
+			totalInodeSize = (totalInodeSize + 31) & ^31
+		}
+
+		// Check block boundary: inode core must not cross a block boundary
+		blockOff := currentOff % w.blockSize
+		if blockOff+inodeSize > w.blockSize {
+			// Align to next block
+			currentOff = (currentOff + w.blockSize - 1) & ^(w.blockSize - 1)
+			e.nid = uint64(currentOff / 32)
+		}
+
+		// Also check that trailing data doesn't cross block boundary for inline layouts
+		if e.layout == disk.LayoutFlatInline {
+			blockOff = currentOff % w.blockSize
+			if blockOff+headerSize+e.trailingSize > w.blockSize {
+				// Fall back to flat-plain (data would cross block boundary)
+				e.layout = disk.LayoutFlatPlain
+				e.trailingSize = w.calcTrailingSize(e)
+				totalInodeSize = headerSize + e.trailingSize
+				if totalInodeSize%32 != 0 {
+					totalInodeSize = (totalInodeSize + 31) & ^31
+				}
+			}
+		}
+
+		currentOff += totalInodeSize
+	}
+
+	w.rootNid = root.nid
+}
+
+// calcTrailingSize returns the number of bytes following the 64-byte inode.
+func (w *erofsWriter) calcTrailingSize(e *erofsEntry) int {
+	switch e.mode & disk.StatTypeMask {
+	case disk.StatTypeReg:
+		if e.layout == disk.LayoutChunkBased {
+			if e.size == 0 && len(e.chunks) == 0 {
+				return 0
+			}
+			cs := w.entryChunkSize(e)
+			nchunks := (int(e.size) + cs - 1) / cs
+			return nchunks * disk.SizeChunkIndex
+		}
+		if e.layout == disk.LayoutFlatInline {
+			return int(e.size)
+		}
+		return 0
+	case disk.StatTypeDir:
+		if e.layout == disk.LayoutFlatInline {
+			return w.direntDataSize(e)
+		}
+		return 0
+	case disk.StatTypeSymlink:
+		if e.layout == disk.LayoutFlatInline {
+			return len(e.symTarget)
+		}
+		return 0
+	default:
+		return 0
+	}
+}
+
+// direntNames returns the sorted list of dirent names for a directory,
+// including "." and "..". EROFS requires dirents within each block to
+// be sorted alphabetically.
+func direntNames(e *erofsEntry) []string {
+	names := make([]string, 0, len(e.children)+2)
+	names = append(names, ".", "..")
+	for _, c := range e.children {
+		names = append(names, c.name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// direntDataSize calculates the serialized EROFS dirent data size for a directory.
+// For multi-block directories, this includes inter-block padding.
+func (w *erofsWriter) direntDataSize(e *erofsEntry) int {
+	names := direntNames(e)
+	nEntries := len(names)
+	if len(e.children) == 0 {
+		// Empty dir still needs "." and ".." entries
+		return 2*disk.SizeDirent + 1 + 2
+	}
+
+	totalSize := 0
+	i := 0
+	for i < nEntries {
+		blockUsed := 0
+		start := i
+		nameSize := 0
+		for j := i; j < nEntries; j++ {
+			headerSize := (j - start + 1) * disk.SizeDirent
+			nameSize += len(names[j])
+			needed := headerSize + nameSize
+			if needed > w.blockSize {
+				break
+			}
+			blockUsed = needed
+			i = j + 1
+		}
+		if i == start {
+			blockUsed = disk.SizeDirent + len(names[i])
+			i++
+		}
+		// Pad non-final blocks to block boundary
+		if i < nEntries && blockUsed%w.blockSize != 0 {
+			blockUsed = (blockUsed + w.blockSize - 1) & ^(w.blockSize - 1)
+		}
+		totalSize += blockUsed
+	}
+
+	return totalSize
+}

--- a/mkfs.go
+++ b/mkfs.go
@@ -1,0 +1,1349 @@
+package erofs
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"math/bits"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/erofs/go-erofs/internal/builder"
+	"github.com/erofs/go-erofs/internal/disk"
+)
+
+// --- Exported types ---
+
+// Writer is a writable filesystem that produces an EROFS image on Close.
+// Files are added via Create, Mkdir, Symlink, and Mknod, then finalized
+// by calling Close which serializes the complete EROFS image.
+type Writer struct {
+	out          io.WriteSeeker
+	closed       bool
+	blockSize    int    // 0 = unset, resolved to defaultBlockSize in Close
+	buildTime    uint64 // from WithBuildTime or buildTimer
+	buildTimeNs  uint32
+	hasBuildTime bool
+	root         *fsEntry            // root directory
+	byPath       map[string]*fsEntry // path → entry (all types)
+
+	devices []uint64 // per-device block counts (one per MetadataOnly source)
+
+	// Per-CopyFrom state, reset at the start of each CopyFrom call.
+	copyMetadataOnly bool   // metadata-only for current CopyFrom
+	copyMerge        bool   // merge mode: apply whiteouts
+	copyDeviceID     uint16 // device ID assigned to current MetadataOnly CopyFrom
+
+	dataFile *os.File // external data file (nil = spool mode)
+	dataOff  int64    // current byte offset in data file
+	spool    *os.File // temp spool (created lazily)
+	spoolOff int64    // current byte offset in spool
+	tempDir  string   // from WithTempDir
+	cpBuf    []byte   // shared buffer for io.Copy into File
+	padBuf   []byte   // shared zero buffer for padding (block-sized, lazy)
+}
+
+// File is a writable regular file returned by Writer.Create.
+// Data is written via Write or ReadFrom, then committed with Close.
+type File struct {
+	fs           *Writer
+	entry        *fsEntry
+	dataStartOff int64 // byte offset where this file's data begins
+	written      int64
+	closed       bool
+}
+
+// CreateOpt configures EROFS image creation.
+type CreateOpt func(*createOptions)
+
+// CopyOpt configures a CopyFrom operation.
+type CopyOpt func(*Writer)
+
+// --- Constructor ---
+
+// Create returns a Writer that produces an EROFS image on Close.
+// Options configure build time, data file, and temp directory.
+func Create(out io.WriteSeeker, opts ...CreateOpt) *Writer {
+	var o createOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	root := &fsEntry{
+		path: "/",
+		mode: disk.StatTypeDir | 0o755,
+	}
+	fsys := &Writer{
+		out:          out,
+		buildTime:    o.buildTime,
+		buildTimeNs:  o.buildTimeNs,
+		hasBuildTime: o.hasBuildTime,
+		root:         root,
+		byPath:       map[string]*fsEntry{"/": root},
+		dataFile:     o.dataFile,
+		tempDir:      o.tempDir,
+	}
+
+	if o.dataFile != nil {
+		// Reserve device slot 0 (DeviceID=1) for the data file.
+		// MetadataOnly CopyFrom device IDs will start at slot 1+.
+		// The reserved slot is filled in with the actual block count at Close.
+		fsys.devices = append(fsys.devices, 0)
+		off, err := o.dataFile.Seek(0, io.SeekEnd)
+		if err == nil {
+			fsys.dataOff = off
+		}
+	}
+
+	return fsys
+}
+
+// --- CopyOpt functions ---
+
+// MetadataOnly configures the current CopyFrom to emit only metadata.
+// Regular files with pre-existing chunk mappings use chunk-based layout
+// referencing an external device; file data is not copied.
+func MetadataOnly() CopyOpt {
+	return func(w *Writer) {
+		w.copyMetadataOnly = true
+	}
+}
+
+// Merge enables overlay merge semantics for the current CopyFrom.
+// AUFS-style whiteout files (.wh.<name>) delete the named entry from
+// prior layers, and opaque markers (.wh..wh..opq) delete all children
+// of their parent directory. The whiteout entries themselves are not
+// added to the image.
+//
+// When using Merge with a source containing AUFS whiteout files, do not
+// pre-convert them; the Writer processes raw whiteout entries directly.
+func Merge() CopyOpt {
+	return func(w *Writer) {
+		w.copyMerge = true
+	}
+}
+
+// --- CreateOpt functions ---
+
+// WithBuildTime sets the filesystem build timestamp.
+func WithBuildTime(sec uint64, nsec uint32) CreateOpt {
+	return func(o *createOptions) {
+		o.buildTime = sec
+		o.buildTimeNs = nsec
+		o.hasBuildTime = true
+	}
+}
+
+// WithDataFile sets an external data file for metadata-only mode.
+// File.Write appends to this file at block-aligned offsets; chunk
+// indexes reference those blocks with DeviceID=1.
+func WithDataFile(f *os.File) CreateOpt {
+	return func(o *createOptions) {
+		o.dataFile = f
+	}
+}
+
+// WithTempDir overrides the temp directory for the spool file.
+// Only used when no data file is provided.
+func WithTempDir(dir string) CreateOpt {
+	return func(o *createOptions) {
+		o.tempDir = dir
+	}
+}
+
+// --- Writer entry methods ---
+
+// Create creates a regular file with default mode 0644. The caller must
+// Close the returned File.
+func (fsys *Writer) Create(name string) (*File, error) {
+	name = cleanPath(name)
+	if name == "/" {
+		return nil, fmt.Errorf("mkfs: cannot create file at root")
+	}
+	if err := fsys.checkPath(name); err != nil {
+		return nil, err
+	}
+
+	fsys.ensureParent(name)
+
+	e := &fsEntry{
+		path: name,
+		mode: disk.StatTypeReg | 0o644,
+	}
+	fsys.addChild(e)
+
+	f := &File{
+		fs:    fsys,
+		entry: e,
+	}
+
+	if fsys.dataFile != nil {
+		f.dataStartOff = fsys.dataOff
+		e.dataStartOff = fsys.dataOff
+	} else {
+		if err := fsys.ensureSpool(); err != nil {
+			return nil, err
+		}
+		f.dataStartOff = fsys.spoolOff
+		e.spoolOff = fsys.spoolOff
+		e.dataStartOff = fsys.spoolOff
+	}
+
+	return f, nil
+}
+
+// Mkdir creates a directory. Only permission bits from perm are used;
+// type bits are forced to directory. Mkdir("/", perm) sets root permissions.
+func (fsys *Writer) Mkdir(name string, perm fs.FileMode) error {
+	name = cleanPath(name)
+	if name == "/" {
+		fsys.root.mode = disk.StatTypeDir | uint16(perm.Perm())
+		return nil
+	}
+	if err := fsys.checkPath(name); err != nil {
+		return err
+	}
+
+	fsys.ensureParent(name)
+
+	e := &fsEntry{
+		path: name,
+		mode: disk.StatTypeDir | uint16(perm.Perm()),
+	}
+	fsys.addChild(e)
+
+	return nil
+}
+
+// Symlink creates newname as a symbolic link to oldname (mode 0777).
+func (fsys *Writer) Symlink(oldname, newname string) error {
+	newname = cleanPath(newname)
+	if newname == "/" {
+		return fmt.Errorf("mkfs: cannot create symlink at root")
+	}
+	if err := fsys.checkPath(newname); err != nil {
+		return err
+	}
+
+	fsys.ensureParent(newname)
+
+	e := &fsEntry{
+		path:       newname,
+		mode:       disk.StatTypeSymlink | 0o777,
+		linkTarget: oldname,
+	}
+	fsys.addChild(e)
+
+	return nil
+}
+
+// Mknod creates a device, FIFO, or socket. mode must include type bits
+// (e.g. disk.StatTypeChrdev | 0o666).
+func (fsys *Writer) Mknod(name string, mode uint16, rdev uint32) error {
+	name = cleanPath(name)
+	if name == "/" {
+		return fmt.Errorf("mkfs: cannot mknod at root")
+	}
+	if err := fsys.checkPath(name); err != nil {
+		return err
+	}
+
+	fsys.ensureParent(name)
+
+	e := &fsEntry{
+		path: name,
+		mode: mode,
+		rdev: rdev,
+	}
+	fsys.addChild(e)
+
+	return nil
+}
+
+// --- Writer metadata methods ---
+
+// Chmod sets permission bits on the named path, preserving type bits.
+func (fsys *Writer) Chmod(name string, mode fs.FileMode) error {
+	e, err := fsys.lookup(name)
+	if err != nil {
+		return err
+	}
+	perm := goModeToUnixMode(mode) & 0o7777
+	e.mode = (e.mode & disk.StatTypeMask) | perm
+	return nil
+}
+
+// Chown sets the owner UID and GID on the named path.
+func (fsys *Writer) Chown(name string, uid, gid int) error {
+	e, err := fsys.lookup(name)
+	if err != nil {
+		return err
+	}
+	e.uid = uint32(uid)
+	e.gid = uint32(gid)
+	return nil
+}
+
+// Chtimes sets the access and modification times on the named path.
+// EROFS only stores mtime; atime is retained for read-back before Close.
+func (fsys *Writer) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	e, err := fsys.lookup(name)
+	if err != nil {
+		return err
+	}
+	e.atime = uint64(atime.Unix())
+	e.atimeNs = uint32(atime.Nanosecond())
+	e.mtime = uint64(mtime.Unix())
+	e.mtimeNs = uint32(mtime.Nanosecond())
+	return nil
+}
+
+// Setxattr sets an extended attribute on the named path.
+func (fsys *Writer) Setxattr(name, attr, value string) error {
+	e, err := fsys.lookup(name)
+	if err != nil {
+		return err
+	}
+	if e.xattrs == nil {
+		e.xattrs = make(map[string]string)
+	}
+	e.xattrs[attr] = value
+	return nil
+}
+
+// SetNlink overrides the computed link count on the named path.
+func (fsys *Writer) SetNlink(name string, nlink uint32) error {
+	e, err := fsys.lookup(name)
+	if err != nil {
+		return err
+	}
+	e.nlink = nlink
+	e.nlinkSet = true
+	return nil
+}
+
+// --- Writer bulk copy ---
+
+// CopyFrom walks an fs.FS and adds all entries.
+// Opens files for data when Entry.Data is nil.
+// Reads symlink targets via readLinker interface when Entry.LinkTarget is empty.
+// If src implements blockSizer, the image block size is set accordingly.
+func (fsys *Writer) CopyFrom(src fs.FS, opts ...CopyOpt) error {
+	// Reset per-CopyFrom state.
+	fsys.copyMetadataOnly = false
+	fsys.copyMerge = false
+	fsys.copyDeviceID = 0
+	for _, opt := range opts {
+		opt(fsys)
+	}
+	// Detect EROFS image source for direct metadata/chunk extraction.
+	// The fast path (copyFromImage) only applies to MetadataOnly mode
+	// where no file data needs to be read — just inodes, dirents, and
+	// chunk indexes. For non-MetadataOnly, fall through to the fs.WalkDir
+	// path which opens files for data.
+	if srcImg, ok := src.(*image); ok {
+		if err := fsys.setBlockSize(int(srcImg.blockSize())); err != nil {
+			return err
+		}
+		if !fsys.hasBuildTime {
+			fsys.buildTime = srcImg.buildTime()
+			fsys.hasBuildTime = true
+		}
+		if fsys.copyMetadataOnly {
+			devBlocks := srcImg.deviceBlocks()
+			fsys.devices = append(fsys.devices, devBlocks...)
+			fsys.copyDeviceID = uint16(len(fsys.devices) - len(devBlocks) + 1)
+			return fsys.copyFromImage(srcImg)
+		}
+	}
+	if bs, ok := src.(blockSizer); ok {
+		if err := fsys.setBlockSize(int(bs.BlockSize())); err != nil {
+			return err
+		}
+	}
+	if fsys.copyMetadataOnly {
+		if db, ok := src.(deviceBlocker); ok {
+			fsys.devices = append(fsys.devices, db.DeviceBlocks())
+			fsys.copyDeviceID = uint16(len(fsys.devices))
+		}
+	}
+	if bt, ok := src.(buildTimer); ok && !fsys.hasBuildTime {
+		fsys.buildTime = bt.BuildTime()
+		fsys.hasBuildTime = true
+	}
+	return fs.WalkDir(src, ".", func(fpath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", fpath, err)
+		}
+
+		// Normalize path to absolute
+		p := "/" + fpath
+		if fpath == "." {
+			p = "/"
+		}
+
+		// Merge mode: process whiteout markers.
+		if fsys.copyMerge && p != "/" {
+			base := path.Base(p)
+			if strings.HasPrefix(base, whiteoutPrefix) {
+				if base == opaqueWhiteout {
+					// Opaque directory: remove all prior children of parent.
+					fsys.removeChildren(path.Dir(p))
+				} else {
+					// File whiteout: remove the named entry.
+					target := path.Join(path.Dir(p), base[len(whiteoutPrefix):])
+					fsys.remove(target)
+				}
+				return nil
+			}
+		}
+
+		// Extract extended metadata from Sys().
+		var be *builder.Entry
+		switch sys := info.Sys().(type) {
+		case *builder.Entry:
+			be = sys
+		case *Stat:
+			// EROFS image source: convert *Stat to *builder.Entry.
+			be = &builder.Entry{
+				UID:     sys.UID,
+				GID:     sys.GID,
+				Mtime:   sys.Mtime,
+				MtimeNs: sys.MtimeNs,
+				Nlink:   uint32(sys.Nlink),
+				Rdev:    sys.Rdev,
+				Xattrs:  sys.Xattrs,
+			}
+		}
+
+		// For regular files, get a data reader.
+		if info.Mode().IsRegular() && info.Size() > 0 && (be == nil || be.Data == nil) {
+			// In metadata-only mode, data is referenced via chunk indexes
+			// from the source — no need to open the file.
+			if fsys.copyMetadataOnly {
+				if be == nil {
+					be = entryFromSys(info)
+					if be == nil {
+						be = &builder.Entry{}
+					}
+				}
+				return fsys.add(p, &entryFileInfo{info: info, sys: be})
+			}
+			// For EROFS sources, use direct SectionReader (bypasses
+			// block-at-a-time reader for contiguous flat-plain data).
+			if srcImg, ok := src.(*image); ok {
+				if st, ok := info.Sys().(*Stat); ok {
+					f := file{img: srcImg, nid: uint64(st.Ino)}
+					if ino, err := f.readInfo(); err == nil {
+						if dr := srcImg.openDirect(ino); dr != nil {
+							if be == nil {
+								be = &builder.Entry{}
+							}
+							be.Data = dr
+							return fsys.add(p, &entryFileInfo{info: info, sys: be})
+						}
+					}
+				}
+			}
+			f, err := src.Open(fpath)
+			if err != nil {
+				return fmt.Errorf("open %s: %w", fpath, err)
+			}
+			if be == nil {
+				be = entryFromSys(info)
+				if be == nil {
+					be = &builder.Entry{}
+				}
+			}
+			be.Data = f.(io.Reader)
+			return fsys.add(p, &entryFileInfo{info: info, sys: be})
+		}
+
+		// For symlinks without LinkTarget, read via ReadLink interface.
+		if info.Mode()&fs.ModeSymlink != 0 && (be == nil || be.LinkTarget == "") {
+			if rl, ok := src.(readLinker); ok {
+				target, err := rl.ReadLink(fpath)
+				if err != nil {
+					return fmt.Errorf("readlink %s: %w", fpath, err)
+				}
+				if be == nil {
+					be = entryFromSys(info)
+					if be == nil {
+						be = &builder.Entry{}
+					}
+				}
+				be.LinkTarget = target
+				return fsys.add(p, &entryFileInfo{info: info, sys: be})
+			}
+		}
+
+		// For directories from plain fs.FS, ensure nlink >= 2.
+		if info.Mode().IsDir() && be == nil {
+			be = entryFromSys(info)
+			if be == nil {
+				be = &builder.Entry{Nlink: 2}
+			}
+			if be.Nlink < 2 {
+				be.Nlink = 2
+			}
+			return fsys.add(p, &entryFileInfo{info: info, sys: be})
+		}
+
+		return fsys.add(p, info)
+	})
+}
+
+// --- Writer finalization ---
+
+// Close writes the EROFS image. The FS must not be used after Close.
+func (fsys *Writer) Close() error {
+	if fsys.closed {
+		return fmt.Errorf("mkfs: FS already closed")
+	}
+	fsys.closed = true
+
+	if fsys.spool != nil {
+		defer func() { _ = fsys.spool.Close() }()
+	}
+
+	fsys.resolveBlockSize()
+
+	if fsys.dataFile != nil {
+		// Fill in the reserved device slot 0 with the actual block count.
+		blocks := (fsys.dataOff + int64(fsys.blockSize) - 1) / int64(fsys.blockSize)
+		fsys.devices[0] = uint64(blocks)
+	}
+
+	buildTime := fsys.buildTime
+	if !fsys.hasBuildTime {
+		buildTime = uint64(time.Now().Unix())
+	}
+
+	// Build erofsEntry tree from the fsEntry tree via BFS.
+	root := fsys.buildErofsTree()
+
+	var chunkBits uint8
+	for cs := fsys.blockSize; cs < 4096; cs <<= 1 {
+		chunkBits++
+	}
+
+	ew := &erofsWriter{
+		buildTime:   buildTime,
+		buildTimeNs: fsys.buildTimeNs,
+		devices:     fsys.devices,
+		blockSize:   fsys.blockSize,
+		chunkBits:   chunkBits,
+		zeroBuf:     make([]byte, fsys.blockSize),
+	}
+
+	ew.planLayout(root)
+	fixParentNids(root, root)
+
+	return ew.write(fsys.out)
+}
+
+// Stat returns file info for the named path. The name is cleaned the same
+// way as other Writer methods (leading slash, no trailing slash).
+func (fsys *Writer) Stat(name string) (fs.FileInfo, error) {
+	name = cleanPath(name)
+	e, ok := fsys.byPath[name]
+	if !ok {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
+	}
+	return &writerFileInfo{entry: e}, nil
+}
+
+// Open opens the named file for reading. For regular files, the file must
+// have been closed (data finalized) before it can be opened for reading.
+// For directories, the returned file implements fs.ReadDirFile.
+func (fsys *Writer) Open(name string) (fs.File, error) {
+	name = cleanPath(name)
+	e, ok := fsys.byPath[name]
+	if !ok {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+
+	typ := e.mode & disk.StatTypeMask
+	switch typ {
+	case disk.StatTypeDir:
+		return &readDir{fsys: fsys, entry: e}, nil
+
+	case disk.StatTypeReg:
+		if !e.fileClosed {
+			return nil, &fs.PathError{Op: "open", Path: name, Err: fmt.Errorf("file not yet closed for writing")}
+		}
+		var sr *io.SectionReader
+		if fsys.dataFile != nil {
+			sr = io.NewSectionReader(fsys.dataFile, e.dataStartOff, int64(e.size))
+		} else if fsys.spool != nil && e.size > 0 {
+			sr = io.NewSectionReader(fsys.spool, e.dataStartOff, int64(e.size))
+		}
+		return &readFile{entry: e, reader: sr}, nil
+
+	default:
+		// Symlinks, devices, etc.: stat-only, no readable data.
+		return &readFile{entry: e}, nil
+	}
+}
+
+// --- File methods ---
+
+// Write appends data to the file.
+func (f *File) Write(p []byte) (int, error) {
+	if f.closed {
+		return 0, fmt.Errorf("mkfs: write to closed file")
+	}
+
+	if f.fs.dataFile != nil {
+		n, err := f.fs.dataFile.Write(p)
+		f.written += int64(n)
+		f.fs.dataOff += int64(n)
+		return n, err
+	}
+
+	n, err := f.fs.spool.Write(p)
+	f.written += int64(n)
+	f.fs.spoolOff += int64(n)
+	return n, err
+}
+
+// ReadFrom implements io.ReaderFrom, allowing io.Copy(f, src) to use
+// a shared buffer instead of allocating a new 32KB buffer per call.
+func (f *File) ReadFrom(r io.Reader) (int64, error) {
+	buf := f.fs.copyBuf()
+	var written int64
+	for {
+		nr, er := r.Read(buf)
+		if nr > 0 {
+			nw, ew := f.Write(buf[:nr])
+			written += int64(nw)
+			if ew != nil {
+				return written, ew
+			}
+		}
+		if er != nil {
+			if er == io.EOF {
+				return written, nil
+			}
+			return written, er
+		}
+	}
+}
+
+// Close commits the file entry. For data file mode, pads to block
+// boundary and records chunk indexes.
+func (f *File) Close() error {
+	if f.closed {
+		return fmt.Errorf("mkfs: file already closed")
+	}
+	f.closed = true
+	f.entry.fileClosed = true
+	f.entry.size = uint64(f.written)
+
+	if f.fs.dataFile != nil {
+		return f.closeDataFile()
+	}
+	return nil
+}
+
+// Chmod sets permission bits on the file, matching os.File.Chmod.
+func (f *File) Chmod(mode fs.FileMode) error {
+	perm := goModeToUnixMode(mode) & 0o7777
+	f.entry.mode = (f.entry.mode & disk.StatTypeMask) | perm
+	return nil
+}
+
+// Chown sets the owner UID and GID on the file, matching os.File.Chown.
+func (f *File) Chown(uid, gid int) error {
+	f.entry.uid = uint32(uid)
+	f.entry.gid = uint32(gid)
+	return nil
+}
+
+// --- Internal types ---
+
+// fsEntry is the in-memory representation of a filesystem entry held by Writer.
+type fsEntry struct {
+	path       string
+	mode       uint16
+	uid, gid   uint32
+	atime      uint64
+	atimeNs    uint32
+	mtime      uint64
+	mtimeNs    uint32
+	nlink      uint32
+	nlinkSet   bool // true if SetNlink was called
+	size       uint64
+	rdev       uint32
+	xattrs     map[string]string
+	linkTarget string
+	chunks     []builder.Chunk
+	contiguous bool // data blocks are contiguous; flat-plain is sufficient
+
+	// Tree structure — maintained during add/remove.
+	parent   *fsEntry
+	children []*fsEntry
+
+	// data location in spool file
+	spoolOff     int64
+	dataStartOff int64     // byte offset where file data begins (spool or data file)
+	fileClosed   bool      // true after File.Close() is called
+	directData   io.Reader // bypasses spool; set by add() for source-provided data
+
+	removed      bool // true if removed by a whiteout in a merge layer
+	metadataOnly bool // from a metadata-only CopyFrom; use chunk-based layout
+}
+
+// createOptions holds the parsed option values for Create.
+type createOptions struct {
+	buildTime    uint64
+	buildTimeNs  uint32
+	hasBuildTime bool
+	dataFile     *os.File // external data file for metadata-only mode
+	tempDir      string   // temp directory for spool file
+}
+
+// blockSizer may be implemented by an fs.FS to declare its block size.
+// Writer.CopyFrom uses this to set the image block size automatically.
+type blockSizer interface {
+	BlockSize() uint32
+}
+
+// buildTimer may be implemented by an fs.FS to suggest a build timestamp.
+// If the caller hasn't set WithBuildTime, CopyFrom uses this value.
+// Entries whose mtime matches the build time can use compact (32-byte) inodes.
+type buildTimer interface {
+	BuildTime() uint64
+}
+
+// deviceBlocker may be implemented by an fs.FS to declare the total
+// block count of its backing device. Writer.CopyFrom uses this to
+// configure the device slot for metadata-only mode.
+type deviceBlocker interface {
+	DeviceBlocks() uint64
+}
+
+// readLinker is an interface for filesystems that support reading symlink targets.
+type readLinker interface {
+	ReadLink(name string) (string, error)
+}
+
+// --- Internal types ---
+
+// erofsEntry is the internal representation of a file/dir/symlink used by the builder.
+type erofsEntry struct {
+	mode    uint16
+	uid     uint32
+	gid     uint32
+	mtime   uint64
+	mtimeNs uint32
+	nlink   uint32
+	size    uint64
+	rdev    uint32
+
+	name      string
+	path      string
+	children  []*erofsEntry
+	symTarget string
+
+	// For regular files — metadata-only mode
+	chunks       []builder.Chunk
+	contiguous   bool  // data blocks are contiguous; use large chunk size
+	chunkBits    uint8 // per-entry chunk bits (0 = use global)
+	metadataOnly bool  // chunk-based layout even without chunks
+
+	// For regular files — full-image mode
+	data io.Reader
+
+	// Extended attributes
+	xattrs map[string]string
+
+	// EROFS layout (assigned during planning)
+	nid           uint64
+	parentNid     uint64
+	erofsFileType uint8
+	layout        uint8
+	compact       bool // true = 32-byte compact inode; false = 64-byte extended
+	xattrSize     int  // bytes of xattr area (0 if no xattrs)
+	trailingSize  int
+
+	// Data block address for flat-plain files (full-image mode)
+	dataBlkAddr uint32
+}
+
+// --- Internal helpers ---
+
+// cleanPath normalizes a filesystem path to an absolute rooted form.
+func cleanPath(p string) string {
+	if p == "" || p == "." || p == "/" {
+		return "/"
+	}
+	p = path.Clean(p)
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return p
+}
+
+// fixParentNids sets the parent NID in the ".." dirent for all directories.
+// This must be called after planLayout has assigned NIDs.
+func fixParentNids(e *erofsEntry, parent *erofsEntry) {
+	e.parentNid = parent.nid
+	for _, c := range e.children {
+		if c.mode&disk.StatTypeMask == disk.StatTypeDir {
+			fixParentNids(c, e)
+		}
+	}
+}
+
+// entryFileInfo wraps an fs.FileInfo but overrides Sys() to return a *builder.Entry.
+type entryFileInfo struct {
+	info fs.FileInfo
+	sys  *builder.Entry
+}
+
+func (fi *entryFileInfo) Name() string       { return fi.info.Name() }
+func (fi *entryFileInfo) Size() int64        { return fi.info.Size() }
+func (fi *entryFileInfo) Mode() fs.FileMode  { return fi.info.Mode() }
+func (fi *entryFileInfo) ModTime() time.Time { return fi.info.ModTime() }
+func (fi *entryFileInfo) IsDir() bool        { return fi.info.IsDir() }
+func (fi *entryFileInfo) Sys() any           { return fi.sys }
+
+// writerFileInfo implements fs.FileInfo for an fsEntry.
+type writerFileInfo struct {
+	entry *fsEntry
+}
+
+func (fi *writerFileInfo) Name() string      { return path.Base(fi.entry.path) }
+func (fi *writerFileInfo) Size() int64       { return int64(fi.entry.size) }
+func (fi *writerFileInfo) Mode() fs.FileMode { return disk.EroFSModeToGoFileMode(fi.entry.mode) }
+func (fi *writerFileInfo) ModTime() time.Time {
+	return time.Unix(int64(fi.entry.mtime), int64(fi.entry.mtimeNs))
+}
+func (fi *writerFileInfo) IsDir() bool { return fi.entry.mode&disk.StatTypeMask == disk.StatTypeDir }
+func (fi *writerFileInfo) Sys() any    { return nil }
+
+// readFile implements fs.File for reading back a finalized file's data.
+type readFile struct {
+	entry  *fsEntry
+	reader *io.SectionReader // nil for empty files or non-regular types
+	closed bool
+}
+
+func (f *readFile) Stat() (fs.FileInfo, error) {
+	return &writerFileInfo{entry: f.entry}, nil
+}
+
+func (f *readFile) Read(p []byte) (int, error) {
+	if f.closed {
+		return 0, fmt.Errorf("mkfs: read from closed file")
+	}
+	if f.reader == nil {
+		return 0, io.EOF
+	}
+	return f.reader.Read(p)
+}
+
+func (f *readFile) Close() error {
+	if f.closed {
+		return fmt.Errorf("mkfs: file already closed")
+	}
+	f.closed = true
+	return nil
+}
+
+// readDir implements fs.ReadDirFile for a directory in Writer.
+type readDir struct {
+	fsys     *Writer
+	entry    *fsEntry
+	children []fs.DirEntry // lazily populated
+	offset   int
+	closed   bool
+}
+
+func (d *readDir) Stat() (fs.FileInfo, error) {
+	return &writerFileInfo{entry: d.entry}, nil
+}
+
+func (d *readDir) Read([]byte) (int, error) {
+	return 0, &fs.PathError{Op: "read", Path: d.entry.path, Err: fmt.Errorf("is a directory")}
+}
+
+func (d *readDir) Close() error {
+	if d.closed {
+		return fmt.Errorf("mkfs: dir already closed")
+	}
+	d.closed = true
+	return nil
+}
+
+func (d *readDir) ReadDir(n int) ([]fs.DirEntry, error) {
+	if d.closed {
+		return nil, fmt.Errorf("mkfs: read from closed dir")
+	}
+	if d.children == nil {
+		d.children = d.collectChildren()
+	}
+
+	if n <= 0 {
+		entries := d.children[d.offset:]
+		d.offset = len(d.children)
+		return entries, nil
+	}
+
+	remaining := d.children[d.offset:]
+	if len(remaining) == 0 {
+		return nil, io.EOF
+	}
+	if n > len(remaining) {
+		n = len(remaining)
+	}
+	entries := remaining[:n]
+	d.offset += n
+	if d.offset >= len(d.children) {
+		return entries, io.EOF
+	}
+	return entries, nil
+}
+
+func (d *readDir) collectChildren() []fs.DirEntry {
+	children := make([]fs.DirEntry, 0, len(d.entry.children))
+	for _, e := range d.entry.children {
+		if e.removed {
+			continue
+		}
+		children = append(children, &dirEntry{entry: e})
+	}
+	sort.Slice(children, func(i, j int) bool {
+		return children[i].Name() < children[j].Name()
+	})
+	return children
+}
+
+// dirEntry implements fs.DirEntry for an fsEntry.
+type dirEntry struct {
+	entry *fsEntry
+}
+
+func (de *dirEntry) Name() string               { return path.Base(de.entry.path) }
+func (de *dirEntry) IsDir() bool                { return de.entry.mode&disk.StatTypeMask == disk.StatTypeDir }
+func (de *dirEntry) Type() fs.FileMode          { return disk.EroFSModeToGoFileMode(de.entry.mode).Type() }
+func (de *dirEntry) Info() (fs.FileInfo, error) { return &writerFileInfo{entry: de.entry}, nil }
+
+// add adds a single entry. Mode and Size come from info; extended metadata
+// comes from info.Sys(). Checks Sys() for *builder.Entry first, then
+// platform-specific stat types as a fallback for plain fs.FS sources.
+func (fsys *Writer) add(p string, info fs.FileInfo) error {
+	p = cleanPath(p)
+	mode := goModeToUnixMode(info.Mode())
+	size := uint64(info.Size())
+	typ := mode & disk.StatTypeMask
+
+	be := entryFromSys(info)
+	if be == nil {
+		be = &builder.Entry{}
+	}
+
+	if p == "/" {
+		root := fsys.root
+		root.mode = mode
+		root.uid = be.UID
+		root.gid = be.GID
+		root.mtime = be.Mtime
+		root.mtimeNs = be.MtimeNs
+		if be.Nlink > 0 {
+			root.nlink = be.Nlink
+			root.nlinkSet = true
+		}
+		root.xattrs = be.Xattrs
+		return nil
+	}
+
+	fsys.ensureParent(p)
+
+	fe := &fsEntry{
+		path:       p,
+		mode:       mode,
+		uid:        be.UID,
+		gid:        be.GID,
+		mtime:      be.Mtime,
+		mtimeNs:    be.MtimeNs,
+		size:       size,
+		rdev:       be.Rdev,
+		xattrs:     be.Xattrs,
+		linkTarget: be.LinkTarget,
+		chunks:     be.Chunks,
+		contiguous: be.Contiguous,
+	}
+	if be.Nlink > 0 {
+		fe.nlink = be.Nlink
+		fe.nlinkSet = true
+	}
+
+	// Handle duplicate paths (overwrite semantics).
+	if existing, ok := fsys.byPath[p]; ok {
+		// Preserve tree linkage when overwriting.
+		savedParent := existing.parent
+		savedChildren := existing.children
+		*existing = *fe
+		existing.parent = savedParent
+		existing.children = savedChildren
+		fe = existing
+	} else {
+		fsys.addChild(fe)
+	}
+
+	if fsys.copyMetadataOnly {
+		fe.metadataOnly = true
+		// Remap chunk DeviceIDs from source-relative to absolute.
+		// For single-device sources, all chunks use DeviceID=1
+		// and get mapped to copyDeviceID.
+		// For multi-device sources (e.g. EROFS images), chunks have
+		// DeviceIDs 1..N that get offset by copyDeviceID-1.
+		if fsys.copyDeviceID > 0 {
+			offset := fsys.copyDeviceID - 1
+			for i := range fe.chunks {
+				fe.chunks[i].DeviceID += offset
+			}
+		}
+	}
+
+	// Write regular file data.
+	// Skip entirely in metadata-only mode.
+	needData := typ == disk.StatTypeReg && size > 0 && be.Data != nil &&
+		!fsys.copyMetadataOnly
+	if needData {
+		// Data is stored locally; clear any source chunk mappings.
+		fe.chunks = nil
+		fe.contiguous = false
+		if fsys.dataFile != nil {
+			// Data file mode: copy through File for block-aligned padding and chunk recording.
+			f := &File{fs: fsys, entry: fe}
+			f.dataStartOff = fsys.dataOff
+			fe.dataStartOff = fsys.dataOff
+			if _, err := f.ReadFrom(be.Data); err != nil {
+				return err
+			}
+			if err := f.Close(); err != nil {
+				return err
+			}
+		} else {
+			// Spool mode: keep a direct reference to avoid copying.
+			fe.directData = be.Data
+			fe.fileClosed = true
+		}
+	} else {
+		fe.fileClosed = true
+	}
+
+	return nil
+}
+
+// checkPath validates that a path hasn't already been registered.
+func (fsys *Writer) checkPath(name string) error {
+	if fsys.closed {
+		return fmt.Errorf("mkfs: FS is closed")
+	}
+	if _, ok := fsys.byPath[name]; ok {
+		return fmt.Errorf("mkfs: duplicate path %q", name)
+	}
+	return nil
+}
+
+// ensureParent creates implicit parent directories for name.
+func (fsys *Writer) ensureParent(name string) {
+	dir := path.Dir(name)
+	if dir == "/" {
+		return
+	}
+	// Walk up to find existing ancestors.
+	var missing []string
+	for d := dir; d != "/"; d = path.Dir(d) {
+		if _, ok := fsys.byPath[d]; ok {
+			break
+		}
+		missing = append(missing, d)
+	}
+	// Create in top-down order.
+	for i := len(missing) - 1; i >= 0; i-- {
+		d := missing[i]
+		e := &fsEntry{
+			path: d,
+			mode: disk.StatTypeDir | 0o755,
+		}
+		fsys.addChild(e)
+	}
+}
+
+// addChild registers an entry in the tree and byPath map.
+// The entry's parent is resolved from its path.
+func (fsys *Writer) addChild(e *fsEntry) {
+	parent := fsys.byPath[path.Dir(e.path)]
+	if parent == nil {
+		parent = fsys.root
+	}
+	e.parent = parent
+	parent.children = append(parent.children, e)
+	fsys.byPath[e.path] = e
+}
+
+// remove marks an entry and all its descendants as removed.
+// Used by Merge to process whiteout deletions.
+func (fsys *Writer) remove(p string) {
+	p = cleanPath(p)
+	e, ok := fsys.byPath[p]
+	if !ok {
+		return
+	}
+	e.removed = true
+	delete(fsys.byPath, p)
+	if e.mode&disk.StatTypeMask == disk.StatTypeDir {
+		fsys.removeSubtree(e)
+	}
+}
+
+// removeChildren marks all descendants of a directory as removed.
+// The directory itself is not removed.
+func (fsys *Writer) removeChildren(dir string) {
+	dir = cleanPath(dir)
+	e, ok := fsys.byPath[dir]
+	if !ok {
+		return
+	}
+	fsys.removeSubtree(e)
+}
+
+// removeSubtree recursively marks all descendants of e as removed.
+func (fsys *Writer) removeSubtree(e *fsEntry) {
+	for _, c := range e.children {
+		if !c.removed {
+			c.removed = true
+			delete(fsys.byPath, c.path)
+			if c.mode&disk.StatTypeMask == disk.StatTypeDir {
+				fsys.removeSubtree(c)
+			}
+		}
+	}
+}
+
+// buildErofsTree converts the fsEntry tree into an erofsEntry tree via BFS.
+// Children are sorted for deterministic output. The Writer is consumed.
+func (fsys *Writer) buildErofsTree() *erofsEntry {
+	type pair struct {
+		fs *fsEntry
+		er *erofsEntry
+	}
+
+	rootEr := fsys.fsToErofs(fsys.root)
+	queue := []pair{{fsys.root, rootEr}}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+
+		// Count child directories for nlink.
+		var childDirs uint32
+		for _, c := range cur.fs.children {
+			if !c.removed && c.mode&disk.StatTypeMask == disk.StatTypeDir {
+				childDirs++
+			}
+		}
+		if !cur.fs.nlinkSet && cur.fs.mode&disk.StatTypeMask == disk.StatTypeDir {
+			cur.er.nlink = 2 + childDirs
+		}
+
+		// Convert and enqueue children.
+		if len(cur.fs.children) > 0 {
+			cur.er.children = make([]*erofsEntry, 0, len(cur.fs.children))
+		}
+		for _, c := range cur.fs.children {
+			if c.removed {
+				continue
+			}
+			ent := fsys.fsToErofs(c)
+			cur.er.children = append(cur.er.children, ent)
+			if c.mode&disk.StatTypeMask == disk.StatTypeDir {
+				queue = append(queue, pair{c, ent})
+			}
+		}
+
+		// Sort children for deterministic output.
+		sort.Slice(cur.er.children, func(i, j int) bool {
+			return cur.er.children[i].name < cur.er.children[j].name
+		})
+	}
+	return rootEr
+}
+
+// fsToErofs converts a single fsEntry to an erofsEntry, resolving data readers.
+func (fsys *Writer) fsToErofs(e *fsEntry) *erofsEntry {
+	var nlink uint32
+	switch {
+	case e.nlinkSet:
+		nlink = e.nlink
+	case e.mode&disk.StatTypeMask == disk.StatTypeDir:
+		nlink = 2 // adjusted by buildErofsTree
+	default:
+		nlink = 1
+	}
+
+	var data io.Reader
+	if fsys.dataFile == nil && len(e.chunks) == 0 && !e.metadataOnly &&
+		e.mode&disk.StatTypeMask == disk.StatTypeReg && e.size > 0 {
+		if e.directData != nil {
+			data = e.directData
+		} else if fsys.spool != nil {
+			data = io.NewSectionReader(fsys.spool, e.spoolOff, int64(e.size))
+		}
+	}
+
+	return &erofsEntry{
+		mode:          e.mode,
+		uid:           e.uid,
+		gid:           e.gid,
+		mtime:         e.mtime,
+		mtimeNs:       e.mtimeNs,
+		nlink:         nlink,
+		size:          e.size,
+		rdev:          e.rdev,
+		name:          path.Base(e.path),
+		path:          e.path,
+		symTarget:     e.linkTarget,
+		chunks:        e.chunks,
+		contiguous:    e.contiguous,
+		metadataOnly:  e.metadataOnly,
+		data:          data,
+		xattrs:        e.xattrs,
+		erofsFileType: modeToFileType(e.mode),
+	}
+}
+
+// setBlockSize sets the image block size. If already set to a different
+// value, it returns an error. Safe to call multiple times with the same value.
+func (fsys *Writer) setBlockSize(n int) error {
+	if n < minBlockSize || n > maxBlockSize {
+		return fmt.Errorf("mkfs: invalid block size %d: must be between %d and %d", n, minBlockSize, maxBlockSize)
+	}
+	if bits.OnesCount(uint(n)) != 1 {
+		return fmt.Errorf("mkfs: invalid block size %d: must be a power of two", n)
+	}
+	if fsys.blockSize == 0 {
+		fsys.blockSize = n
+		return nil
+	}
+	if fsys.blockSize != n {
+		return fmt.Errorf("mkfs: block size conflict: already %d, requested %d", fsys.blockSize, n)
+	}
+	return nil
+}
+
+// resolveBlockSize returns the block size, defaulting to 4096 if unset.
+func (fsys *Writer) resolveBlockSize() int {
+	if fsys.blockSize == 0 {
+		fsys.blockSize = defaultBlockSize
+	}
+	return fsys.blockSize
+}
+
+// copyBuf returns a shared 32KB buffer for io.Copy operations.
+func (fsys *Writer) copyBuf() []byte {
+	if fsys.cpBuf == nil {
+		fsys.cpBuf = make([]byte, 32*1024)
+	}
+	return fsys.cpBuf
+}
+
+// zeroPad returns a shared zero buffer sized to the resolved block size.
+func (fsys *Writer) zeroPad() []byte {
+	if fsys.padBuf == nil {
+		fsys.padBuf = make([]byte, fsys.resolveBlockSize())
+	}
+	return fsys.padBuf
+}
+
+// ensureSpool lazily creates the spool temp file.
+func (fsys *Writer) ensureSpool() error {
+	if fsys.spool != nil {
+		return nil
+	}
+	tmp, err := os.CreateTemp(fsys.tempDir, "erofs-mkfs-*")
+	if err != nil {
+		return fmt.Errorf("mkfs: create spool: %w", err)
+	}
+	_ = os.Remove(tmp.Name()) // unlink immediately; fd keeps data accessible
+	fsys.spool = tmp
+	return nil
+}
+
+func (fsys *Writer) lookup(name string) (*fsEntry, error) {
+	name = cleanPath(name)
+	e, ok := fsys.byPath[name]
+	if !ok {
+		return nil, fmt.Errorf("mkfs: path not found %q", name)
+	}
+	return e, nil
+}
+
+// closeDataFile pads the data file to a block boundary and records chunks.
+func (f *File) closeDataFile() error {
+	if f.written == 0 {
+		return nil
+	}
+
+	// Pad to block boundary.
+	bs := int64(f.fs.resolveBlockSize())
+	rem := f.fs.dataOff % bs
+	if rem != 0 {
+		padSize := bs - rem
+		n, err := f.fs.dataFile.Write(f.fs.zeroPad()[:padSize])
+		f.fs.dataOff += int64(n)
+		if err != nil {
+			return fmt.Errorf("mkfs: pad data file: %w", err)
+		}
+	}
+
+	// Compute chunks from the start offset and written bytes.
+	startBlock := uint64(f.dataStartOff) / uint64(f.fs.resolveBlockSize())
+	totalBlocks := (uint64(f.written) + uint64(f.fs.resolveBlockSize()) - 1) / uint64(f.fs.resolveBlockSize())
+
+	for totalBlocks > 0 {
+		count := totalBlocks
+		if count > 65535 {
+			count = 65535
+		}
+		f.entry.chunks = append(f.entry.chunks, builder.Chunk{
+			PhysicalBlock: startBlock,
+			Count:         uint16(count),
+			DeviceID:      1,
+		})
+		startBlock += count
+		totalBlocks -= count
+	}
+
+	return nil
+}
+
+// --- Constants ---
+
+const (
+	minBlockSize     = 512
+	defaultBlockSize = 4096
+	nullAddr         = 0xFFFFFFFF // marks a hole/sparse chunk
+
+	// Overlay whiteout markers (AUFS convention used by OCI layers).
+	whiteoutPrefix = ".wh."
+	opaqueWhiteout = ".wh..wh..opq"
+)
+
+// blkBits returns log2(blockSize).
+func blkBits(blockSize int) uint8 {
+	return uint8(bits.TrailingZeros(uint(blockSize)))
+}

--- a/mkfs_darwin.go
+++ b/mkfs_darwin.go
@@ -1,0 +1,26 @@
+package erofs
+
+import (
+	"io/fs"
+	"syscall"
+
+	"github.com/erofs/go-erofs/internal/builder"
+)
+
+func entryFromSys(info fs.FileInfo) *builder.Entry {
+	switch sys := info.Sys().(type) {
+	case *builder.Entry:
+		return sys
+	case *syscall.Stat_t:
+		return &builder.Entry{
+			UID:     sys.Uid,
+			GID:     sys.Gid,
+			Mtime:   uint64(sys.Mtimespec.Sec),
+			MtimeNs: uint32(sys.Mtimespec.Nsec),
+			Nlink:   uint32(sys.Nlink),
+			Rdev:    uint32(sys.Rdev),
+		}
+	default:
+		return nil
+	}
+}

--- a/mkfs_image.go
+++ b/mkfs_image.go
@@ -1,0 +1,500 @@
+package erofs
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"path"
+
+	"github.com/erofs/go-erofs/internal/builder"
+	"github.com/erofs/go-erofs/internal/disk"
+)
+
+// newMetaReader returns an at() function backed by an eagerly-read
+// metadata buffer plus an on-demand block cache for data blocks
+// outside the metadata region.
+func newMetaReader(ra io.ReaderAt, metaStart, totalBytes int64, blockSize int) func(int64) []byte {
+	metaSize := totalBytes - metaStart
+	if metaSize <= 0 {
+		return func(int64) []byte { return nil }
+	}
+	metaBuf := make([]byte, metaSize)
+	if n, err := ra.ReadAt(metaBuf, metaStart); err != nil || int64(n) != metaSize {
+		return func(int64) []byte { return nil }
+	}
+
+	cache := make(map[int64][]byte)
+
+	return func(off int64) []byte {
+		// Fast path: offset in metadata region.
+		if off >= metaStart {
+			o := off - metaStart
+			if o >= int64(len(metaBuf)) {
+				return nil
+			}
+			return metaBuf[o:]
+		}
+		// Outside metadata — flat-plain data block. Load on demand.
+		if off < 0 || off >= totalBytes {
+			return nil
+		}
+		blkAddr := off - off%int64(blockSize)
+		if cached, ok := cache[blkAddr]; ok {
+			return cached[off-blkAddr:]
+		}
+		sz := int64(blockSize)
+		if blkAddr+sz > totalBytes {
+			sz = totalBytes - blkAddr
+		}
+		buf := make([]byte, sz)
+		if n, err := ra.ReadAt(buf, blkAddr); err != nil || int64(n) != sz {
+			return nil
+		}
+		cache[blkAddr] = buf
+		return buf[off-blkAddr:]
+	}
+}
+
+// imgQEntry is a BFS queue entry for the image metadata walk.
+type imgQEntry struct {
+	nid  uint64
+	path string
+}
+
+// copyFromImage is a fast path for CopyFrom when the source is an *image.
+// Instead of walking via the fs.FS interface (which does per-inode ReadAt
+// syscalls), it reads the entire metadata area into memory and parses
+// inodes, directory entries, xattrs, and chunk indexes directly from the
+// buffer. This reduces thousands of syscalls to a single ReadAt.
+func (fsys *Writer) copyFromImage(img *image) error {
+	metaStart := img.metaStartPos()
+	totalBytes := int64(img.sb.Blocks) << img.sb.BlkSizeBits
+	if totalBytes <= 0 {
+		return nil
+	}
+
+	blkBits := img.sb.BlkSizeBits
+	buildTime := img.sb.BuildTime
+	buildTimeNs := img.sb.BuildTimeNs
+
+	blockSize := int(1 << blkBits)
+
+	// Get an accessor for image data. Reads the metadata region eagerly
+	// and loads flat-plain data blocks on demand.
+	at := newMetaReader(img.meta, metaStart, totalBytes, blockSize)
+
+	// Shared xattr block address (if present). The at() function
+	// will load the block on demand when xattrs are parsed.
+	var sharedXattrOff int64
+	if img.sb.XattrBlkAddr > 0 {
+		sharedXattrOff = int64(img.sb.XattrBlkAddr) << blkBits
+	}
+
+	// Pre-allocate based on inode count from superblock.
+	inodeCount := int(img.sb.Inos)
+	if inodeCount == 0 {
+		inodeCount = 64
+	}
+	queue := make([]imgQEntry, 0, inodeCount)
+	queue = append(queue, imgQEntry{nid: uint64(img.sb.RootNid), path: "/"})
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+
+		// Merge mode: process whiteout markers.
+		if fsys.copyMerge && cur.path != "/" {
+			base := path.Base(cur.path)
+			if len(base) > len(whiteoutPrefix) && base[:len(whiteoutPrefix)] == whiteoutPrefix {
+				if base == opaqueWhiteout {
+					fsys.removeChildren(path.Dir(cur.path))
+				} else {
+					target := path.Dir(cur.path) + "/" + base[len(whiteoutPrefix):]
+					if path.Dir(cur.path) == "/" {
+						target = "/" + base[len(whiteoutPrefix):]
+					}
+					fsys.remove(target)
+				}
+				continue
+			}
+		}
+
+		inodeAddr := metaStart + int64(cur.nid*disk.SizeInodeCompact)
+		buf := at(inodeAddr)
+		if len(buf) < disk.SizeInodeCompact {
+			return fmt.Errorf("inode %d out of range", cur.nid)
+		}
+
+		format := binary.LittleEndian.Uint16(buf[:2])
+		layout := uint8((format & 0x0E) >> 1)
+		compact := format&0x01 == 0
+
+		if compact && len(buf) < disk.SizeInodeCompact {
+			return fmt.Errorf("compact inode %d out of range", cur.nid)
+		}
+		if !compact && len(buf) < disk.SizeInodeExtended {
+			return fmt.Errorf("extended inode %d out of range", cur.nid)
+		}
+
+		var (
+			mode    uint16
+			uid     uint32
+			gid     uint32
+			nlink   uint32
+			size    uint64
+			idata   uint32
+			mtime   uint64
+			mtimeNs uint32
+			xcnt    uint16
+			icSize  int
+		)
+
+		if compact {
+			var ino disk.InodeCompact
+			if _, err := binary.Decode(buf[:disk.SizeInodeCompact], binary.LittleEndian, &ino); err != nil {
+				return fmt.Errorf("decode compact inode %d: %w", cur.nid, err)
+			}
+			mode = ino.Mode
+			uid = uint32(ino.UID)
+			gid = uint32(ino.GID)
+			nlink = uint32(ino.Nlink)
+			size = uint64(ino.Size)
+			idata = ino.InodeData
+			mtime = buildTime
+			mtimeNs = buildTimeNs
+			xcnt = ino.XattrCount
+			icSize = disk.SizeInodeCompact
+		} else {
+			var ino disk.InodeExtended
+			if _, err := binary.Decode(buf[:disk.SizeInodeExtended], binary.LittleEndian, &ino); err != nil {
+				return fmt.Errorf("decode extended inode %d: %w", cur.nid, err)
+			}
+			mode = ino.Mode
+			uid = ino.UID
+			gid = ino.GID
+			nlink = ino.Nlink
+			size = ino.Size
+			idata = ino.InodeData
+			mtime = ino.Mtime
+			mtimeNs = ino.MtimeNs
+			xcnt = ino.XattrCount
+			icSize = disk.SizeInodeExtended
+		}
+
+		// Parse xattr area.
+		xattrSize := 0
+		if xcnt > 0 {
+			xattrSize = int(xcnt-1)*disk.SizeXattrEntry + disk.SizeXattrBodyHeader
+		}
+		var xattrs map[string]string
+		if xattrSize > 0 {
+			xattrAddr := inodeAddr + int64(icSize)
+			xb := at(xattrAddr)
+			if len(xb) >= xattrSize {
+				xattrs = parseXattrsFromBuf(xb[:xattrSize], at, sharedXattrOff, img.getLongPrefix)
+			}
+		}
+
+		trailingAddr := inodeAddr + int64(icSize) + int64(xattrSize)
+		typ := mode & disk.StatTypeMask
+
+		// Build fsEntry directly, bypassing builder.Entry + add() overhead.
+		fe := &fsEntry{
+			path:    cur.path,
+			mode:    mode,
+			uid:     uid,
+			gid:     gid,
+			mtime:   mtime,
+			mtimeNs: mtimeNs,
+			size:    size,
+			xattrs:  xattrs,
+		}
+		if nlink > 0 {
+			fe.nlink = nlink
+			fe.nlinkSet = true
+		}
+		fe.fileClosed = true
+		if fsys.copyMetadataOnly {
+			fe.metadataOnly = true
+		}
+
+		switch typ {
+		case disk.StatTypeDir:
+			dirSize := int(size)
+			if dirSize > 0 {
+				var dirData []byte
+				switch layout {
+				case disk.LayoutFlatPlain:
+					dataAddr := int64(idata) << blkBits
+					d := at(dataAddr)
+					if d != nil && len(d) >= dirSize {
+						dirData = d[:dirSize]
+					} else {
+						dirData = make([]byte, dirSize)
+						if _, err := img.meta.ReadAt(dirData, dataAddr); err != nil {
+							return fmt.Errorf("read dir data for nid %d: %w", cur.nid, err)
+						}
+					}
+				case disk.LayoutFlatInline:
+					d := at(trailingAddr)
+					if d != nil && len(d) >= dirSize {
+						dirData = d[:dirSize]
+					}
+				}
+				if dirData != nil {
+					fsys.parseDirBlock(dirData, dirSize, blockSize, cur.path, &queue)
+				}
+			}
+
+		case disk.StatTypeSymlink:
+			if size > 0 {
+				var linkData []byte
+				if layout == disk.LayoutFlatPlain {
+					linkData = make([]byte, size)
+					if _, err := img.meta.ReadAt(linkData, int64(idata)<<blkBits); err != nil {
+						return fmt.Errorf("read symlink data for nid %d: %w", cur.nid, err)
+					}
+				} else {
+					linkData = at(trailingAddr)
+				}
+				if linkData != nil && int(size) <= len(linkData) {
+					fe.linkTarget = string(linkData[:size])
+				}
+			}
+
+		case disk.StatTypeReg:
+			if layout == disk.LayoutChunkBased && size > 0 {
+				chunkFmt := uint16(idata)
+				if chunkFmt&disk.LayoutChunkFormatIndexes != 0 {
+					chunkAddr := trailingAddr
+					if chunkAddr%8 != 0 {
+						chunkAddr = (chunkAddr + 7) & ^int64(7)
+					}
+					fe.chunks = fsys.parseChunks(at(chunkAddr), chunkFmt, size, blkBits, img.deviceIDMask)
+					fe.contiguous = true
+				}
+			}
+
+		case disk.StatTypeChrdev, disk.StatTypeBlkdev:
+			fe.rdev = disk.RdevFromMode(mode, idata)
+		}
+
+		// Remap chunk DeviceIDs for metadata-only sources.
+		if fsys.copyMetadataOnly && fsys.copyDeviceID > 0 {
+			offset := fsys.copyDeviceID - 1
+			for i := range fe.chunks {
+				fe.chunks[i].DeviceID += offset
+			}
+		}
+
+		// Register in the tree.
+		if cur.path == "/" {
+			// Update root metadata.
+			fsys.root.mode = fe.mode
+			fsys.root.uid = fe.uid
+			fsys.root.gid = fe.gid
+			fsys.root.mtime = fe.mtime
+			fsys.root.mtimeNs = fe.mtimeNs
+			fsys.root.nlink = fe.nlink
+			fsys.root.nlinkSet = fe.nlinkSet
+			fsys.root.xattrs = fe.xattrs
+		} else if existing, ok := fsys.byPath[cur.path]; ok {
+			// Merge overwrites: preserve tree linkage.
+			savedParent := existing.parent
+			savedChildren := existing.children
+			*existing = *fe
+			existing.parent = savedParent
+			existing.children = savedChildren
+		} else {
+			fsys.addChild(fe)
+		}
+	}
+	return nil
+}
+
+// parseDirBlock extracts directory entries from dirent data and enqueues
+// child inodes for BFS traversal.
+func (fsys *Writer) parseDirBlock(data []byte, dirSize, blockSize int, parentPath string, queue *[]imgQEntry) {
+	pos := 0
+	for pos < dirSize {
+		blockEnd := pos + blockSize
+		if blockEnd > dirSize {
+			blockEnd = dirSize
+		}
+		blk := data[pos:blockEnd]
+		if len(blk) < disk.SizeDirent {
+			break
+		}
+
+		firstNameOff := binary.LittleEndian.Uint16(blk[8:10])
+		nEntries := int(firstNameOff / disk.SizeDirent)
+		if nEntries == 0 || nEntries*disk.SizeDirent > len(blk) {
+			break
+		}
+
+		for i := 0; i < nEntries; i++ {
+			off := i * disk.SizeDirent
+			nid := binary.LittleEndian.Uint64(blk[off : off+8])
+			nameOff := int(binary.LittleEndian.Uint16(blk[off+8 : off+10]))
+
+			var nameEnd int
+			if i < nEntries-1 {
+				nameEnd = int(binary.LittleEndian.Uint16(blk[(i+1)*disk.SizeDirent+8 : (i+1)*disk.SizeDirent+10]))
+			} else {
+				nameEnd = len(blk)
+			}
+			if nameOff >= len(blk) || nameEnd > len(blk) || nameOff >= nameEnd {
+				continue
+			}
+
+			// Extract name, trimming trailing NUL padding.
+			nameBytes := blk[nameOff:nameEnd]
+			for len(nameBytes) > 0 && nameBytes[len(nameBytes)-1] == 0 {
+				nameBytes = nameBytes[:len(nameBytes)-1]
+			}
+			name := string(nameBytes)
+			if name == "." || name == ".." || name == "" {
+				continue
+			}
+
+			childPath := parentPath + "/" + name
+			if parentPath == "/" {
+				childPath = "/" + name
+			}
+			*queue = append(*queue, imgQEntry{nid: nid, path: childPath})
+		}
+
+		pos = blockEnd
+	}
+}
+
+// parseChunks extracts chunk index entries from an in-memory buffer.
+func (fsys *Writer) parseChunks(data []byte, chunkFmt uint16, fileSize uint64, blkBits uint8, deviceIDMask uint16) []builder.Chunk {
+	chunkBits := blkBits + uint8(chunkFmt&disk.LayoutChunkFormatBits)
+	nchunks := int((fileSize-1)>>chunkBits) + 1
+	blocksPerChunk := 1 << (chunkBits - blkBits)
+
+	// Align to 8 bytes for index entries.
+	needed := nchunks * disk.SizeChunkIndex
+	if len(data) < needed {
+		return nil
+	}
+
+	chunks := make([]builder.Chunk, 0, nchunks)
+	for i := range nchunks {
+		off := i * disk.SizeChunkIndex
+		startBlkLo := binary.LittleEndian.Uint32(data[off+4 : off+8])
+		if ^startBlkLo == 0 {
+			continue // null/hole
+		}
+		startBlkHi := binary.LittleEndian.Uint16(data[off : off+2])
+		deviceID := binary.LittleEndian.Uint16(data[off+2:off+4]) & deviceIDMask
+		physBlock := (uint64(startBlkHi) << 32) | uint64(startBlkLo)
+
+		if len(chunks) > 0 {
+			prev := &chunks[len(chunks)-1]
+			if prev.DeviceID == deviceID &&
+				prev.PhysicalBlock+uint64(prev.Count) == physBlock &&
+				int(prev.Count)+blocksPerChunk <= 65535 {
+				prev.Count += uint16(blocksPerChunk)
+				continue
+			}
+		}
+		chunks = append(chunks, builder.Chunk{
+			PhysicalBlock: physBlock,
+			Count:         uint16(blocksPerChunk),
+			DeviceID:      deviceID,
+		})
+	}
+	return chunks
+}
+
+// parseXattrsFromBuf parses xattr entries from an in-memory buffer.
+// at provides on-demand access to the shared xattr block at sharedOff.
+// longPrefix resolves long xattr prefix indexes (NameIndex with high bit set).
+func parseXattrsFromBuf(buf []byte, at func(int64) []byte, sharedOff int64, longPrefix func(uint8) (string, error)) map[string]string {
+	if len(buf) < disk.SizeXattrBodyHeader {
+		return nil
+	}
+
+	var xh disk.XattrHeader
+	if _, err := binary.Decode(buf[:disk.SizeXattrBodyHeader], binary.LittleEndian, &xh); err != nil {
+		return nil
+	}
+	pos := disk.SizeXattrBodyHeader
+
+	xattrs := make(map[string]string)
+
+	// Resolve shared xattr references.
+	for i := 0; i < int(xh.SharedCount) && pos+4 <= len(buf); i++ {
+		idx := binary.LittleEndian.Uint32(buf[pos : pos+4])
+		pos += 4
+
+		if sharedOff == 0 {
+			continue
+		}
+		sharedBlock := at(sharedOff + int64(idx)*4)
+		if sharedBlock == nil || len(sharedBlock) < disk.SizeXattrEntry {
+			continue
+		}
+		var xe disk.XattrEntry
+		if _, err := binary.Decode(sharedBlock[:disk.SizeXattrEntry], binary.LittleEndian, &xe); err != nil {
+			continue
+		}
+		entryLen := int(xe.NameLen) + int(xe.ValueLen)
+		if disk.SizeXattrEntry+entryLen > len(sharedBlock) {
+			continue
+		}
+		sb := sharedBlock[disk.SizeXattrEntry:]
+		name := xattrName(xe, sb[:xe.NameLen], longPrefix)
+		value := string(sb[xe.NameLen : int(xe.NameLen)+int(xe.ValueLen)])
+		xattrs[name] = value
+	}
+
+	// Parse inline xattr entries.
+	for pos+disk.SizeXattrEntry <= len(buf) {
+		var xe disk.XattrEntry
+		if _, err := binary.Decode(buf[pos:pos+disk.SizeXattrEntry], binary.LittleEndian, &xe); err != nil {
+			break
+		}
+		pos += disk.SizeXattrEntry
+
+		entryLen := int(xe.NameLen) + int(xe.ValueLen)
+		if pos+entryLen > len(buf) {
+			break
+		}
+
+		name := xattrName(xe, buf[pos:pos+int(xe.NameLen)], longPrefix)
+		pos += int(xe.NameLen)
+		value := string(buf[pos : pos+int(xe.ValueLen)])
+		pos += int(xe.ValueLen)
+
+		xattrs[name] = value
+
+		// Round up to 4-byte boundary.
+		if rem := pos % 4; rem != 0 {
+			pos += 4 - rem
+		}
+	}
+	if len(xattrs) == 0 {
+		return nil
+	}
+	return xattrs
+}
+
+// xattrName builds the full xattr name from an entry and its raw name bytes.
+// longPrefix resolves long prefix indexes when the high bit of NameIndex is set.
+func xattrName(xe disk.XattrEntry, rawName []byte, longPrefix func(uint8) (string, error)) string {
+	var prefix string
+	if xe.NameIndex&0x80 != 0 {
+		// Long prefix: high bit set, low 7 bits index the prefix table.
+		if longPrefix != nil {
+			if p, err := longPrefix(xe.NameIndex & 0x7F); err == nil {
+				prefix = p
+			}
+		}
+	} else if xe.NameIndex != 0 {
+		prefix = xattrIndex(xe.NameIndex).String()
+	}
+	return prefix + string(rawName)
+}

--- a/mkfs_other.go
+++ b/mkfs_other.go
@@ -1,0 +1,16 @@
+//go:build !linux && !darwin
+
+package erofs
+
+import (
+	"io/fs"
+
+	"github.com/erofs/go-erofs/internal/builder"
+)
+
+func entryFromSys(info fs.FileInfo) *builder.Entry {
+	if be, ok := info.Sys().(*builder.Entry); ok {
+		return be
+	}
+	return nil
+}

--- a/mkfs_test.go
+++ b/mkfs_test.go
@@ -1,0 +1,1389 @@
+package erofs_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	erofs "github.com/erofs/go-erofs"
+	"github.com/erofs/go-erofs/internal/builder"
+	"github.com/erofs/go-erofs/internal/disk"
+	"github.com/erofs/go-erofs/internal/erofstest"
+)
+
+// TestCreateFSSpool exercises spool mode: CreateFS without a data file.
+func TestCreateFSSpool(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	// Create a regular file.
+	f, err := fsys.Create("/hello.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("hello world\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a directory and a file inside it.
+	if err := fsys.Mkdir("/subdir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f2, err := fsys.Create("/subdir/nested.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f2.Write([]byte("nested\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f2.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink.
+	if err := fsys.Symlink("hello.txt", "/link"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an empty file.
+	f3, err := fsys.Create("/empty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f3.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+
+	// Read back the image.
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	erofstest.CheckFile(t, efs, "hello.txt", "hello world\n")
+	erofstest.CheckFile(t, efs, "subdir/nested.txt", "nested\n")
+	erofstest.CheckFile(t, efs, "empty", "")
+	erofstest.CheckSymlink(t, efs, "link", "hello.txt")
+	erofstest.CheckDirEntries(t, efs, ".", []string{"empty", "hello.txt", "link", "subdir"})
+	erofstest.CheckDirEntries(t, efs, "subdir", []string{"nested.txt"})
+}
+
+// TestCreateFSDataFile exercises data file mode (metadata-only).
+func TestCreateFSDataFile(t *testing.T) {
+	dataPath := filepath.Join(t.TempDir(), "data.bin")
+	df, err := os.Create(dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = df.Close() }()
+
+	var metaBuf testBuffer
+	fsys := erofs.Create(&metaBuf, erofs.WithDataFile(df))
+
+	f, err := fsys.Create("/hello.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("data file mode\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	f2, err := fsys.Create("/big.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := bytes.Repeat([]byte("ABCDEFGH"), 1024) // 8KB
+	if _, err := f2.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := f2.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	// Re-open data file as ReaderAt for verification.
+	dfRead, err := os.Open(dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = dfRead.Close() }()
+
+	efs, err := erofs.Open(bytes.NewReader(metaBuf.Bytes()), erofs.WithExtraDevices(dfRead))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	erofstest.CheckFile(t, efs, "hello.txt", "data file mode\n")
+	erofstest.CheckFileBytes(t, efs, "big.bin", data)
+}
+
+// TestCreateFSMetadata verifies Chmod, Chown, Setxattr, SetMtime.
+func TestCreateFSMetadata(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	f, err := fsys.Create("/file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("content\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Chmod(0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Chown(1000, 2000); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Setxattr("/file.txt", "user.test", "value123"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Chtimes("/file.txt", time.Time{}, time.Unix(1700000000, 123456789)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Mkdir("/mydir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Chmod("/mydir", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Chown("/mydir", 500, 600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	// Check file metadata.
+	st := erofstest.Stat(t, efs, "file.txt")
+	if st.Mode.Perm() != 0o755 {
+		t.Errorf("file perm: got %o, want 755", st.Mode.Perm())
+	}
+	if st.UID != 1000 || st.GID != 2000 {
+		t.Errorf("file uid/gid: got %d/%d, want 1000/2000", st.UID, st.GID)
+	}
+	if st.Mtime != 1700000000 {
+		t.Errorf("file mtime: got %d, want 1700000000", st.Mtime)
+	}
+	if st.MtimeNs != 123456789 {
+		t.Errorf("file mtimeNs: got %d, want 123456789", st.MtimeNs)
+	}
+	erofstest.CheckXattrs(t, efs, "file.txt", map[string]string{"user.test": "value123"})
+
+	// Check dir metadata.
+	dst := erofstest.Stat(t, efs, "mydir")
+	if dst.Mode.Perm() != 0o700 {
+		t.Errorf("dir perm: got %o, want 700", dst.Mode.Perm())
+	}
+	if dst.UID != 500 || dst.GID != 600 {
+		t.Errorf("dir uid/gid: got %d/%d, want 500/600", dst.UID, dst.GID)
+	}
+}
+
+// TestCreateFSMknod verifies char and block device creation.
+func TestCreateFSMknod(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	if err := fsys.Mknod("/null", disk.StatTypeChrdev|0o666, 1<<8|3); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Mknod("/sda", disk.StatTypeBlkdev|0o660, 8<<8); err != nil { //nolint:staticcheck // minor=0
+		t.Fatal(err)
+	}
+
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	erofstest.CheckDevice(t, efs, "null", fs.ModeCharDevice, 1<<8|3)
+	erofstest.CheckDevice(t, efs, "sda", fs.ModeDevice, 8<<8) //nolint:staticcheck // minor=0
+}
+
+// TestCreateFSLargeFile tests a file that spans many blocks and exercises
+// the Chunk.Count uint16 split for files > 65535 blocks.
+func TestCreateFSLargeFile(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	// 128KB file — enough to span multiple blocks but not absurdly large.
+	data := make([]byte, 128*1024)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+
+	f, err := fsys.Create("/large.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	erofstest.CheckFileBytes(t, efs, "large.bin", data)
+}
+
+// TestCreateFSLargeFileDataFile tests a large file with data file mode,
+// including chunk splitting for files > 65535 blocks.
+func TestCreateFSLargeFileDataFile(t *testing.T) {
+	dataPath := filepath.Join(t.TempDir(), "data.bin")
+	df, err := os.Create(dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = df.Close() }()
+
+	var metaBuf testBuffer
+	fsys := erofs.Create(&metaBuf, erofs.WithDataFile(df))
+
+	// 128KB file.
+	data := make([]byte, 128*1024)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+
+	f, err := fsys.Create("/large.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	dfRead, err := os.Open(dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = dfRead.Close() }()
+
+	efs, err := erofs.Open(bytes.NewReader(metaBuf.Bytes()), erofs.WithExtraDevices(dfRead))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	erofstest.CheckFileBytes(t, efs, "large.bin", data)
+}
+
+// TestCreateFSErrors tests error cases.
+func TestCreateFSErrors(t *testing.T) {
+	t.Run("duplicate path", func(t *testing.T) {
+		var buf testBuffer
+		fsys := erofs.Create(&buf)
+		f, err := fsys.Create("/dup.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		_, err = fsys.Create("/dup.txt")
+		if err == nil {
+			t.Fatal("expected error for duplicate path")
+		}
+	})
+
+	t.Run("write after close", func(t *testing.T) {
+		var buf testBuffer
+		fsys := erofs.Create(&buf)
+		f, err := fsys.Create("/file.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write([]byte("data")); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = f.Write([]byte("more"))
+		if err == nil {
+			t.Fatal("expected error writing to closed file")
+		}
+	})
+
+	t.Run("file double close", func(t *testing.T) {
+		var buf testBuffer
+		fsys := erofs.Create(&buf)
+		f, err := fsys.Create("/file.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		err = f.Close()
+		if err == nil {
+			t.Fatal("expected error on double close")
+		}
+	})
+
+	t.Run("FS double close", func(t *testing.T) {
+		var buf testBuffer
+		fsys := erofs.Create(&buf)
+		if err := fsys.Close(); err != nil {
+			t.Fatal(err)
+		}
+		err := fsys.Close()
+		if err == nil {
+			t.Fatal("expected error on FS double close")
+		}
+	})
+
+	t.Run("create after FS close", func(t *testing.T) {
+		var buf testBuffer
+		fsys := erofs.Create(&buf)
+		if err := fsys.Close(); err != nil {
+			t.Fatal(err)
+		}
+		_, err := fsys.Create("/file.txt")
+		if err == nil {
+			t.Fatal("expected error creating after FS close")
+		}
+	})
+}
+
+// TestCreateFSImplicitDirs verifies that parent directories are created
+// implicitly when creating deeply nested files.
+func TestCreateFSImplicitDirs(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	f, err := fsys.Create("/a/b/c/deep.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("deep\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	erofstest.CheckFile(t, efs, "a/b/c/deep.txt", "deep\n")
+
+	// Verify implicit directories exist.
+	for _, dir := range []string{"a", "a/b", "a/b/c"} {
+		fi, err := fs.Stat(efs, dir)
+		if err != nil {
+			t.Errorf("stat %s: %v", dir, err)
+			continue
+		}
+		if !fi.IsDir() {
+			t.Errorf("%s: not a directory", dir)
+		}
+	}
+}
+
+// TestCreateFSEmpty verifies that an empty FS produces a valid image.
+func TestCreateFSEmpty(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	entries, err := fs.ReadDir(efs, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected empty root dir, got %d entries", len(entries))
+	}
+}
+
+// TestCreateFSSetNlink verifies that SetNlink overrides computed nlink.
+func TestCreateFSSetNlink(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	f, err := fsys.Create("/file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("data")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.SetNlink("/file.txt", 42); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	st := erofstest.Stat(t, efs, "file.txt")
+	if st.Nlink != 42 {
+		t.Errorf("nlink: got %d, want 42", st.Nlink)
+	}
+}
+
+// TestCreateFSDirNlink verifies that directory nlink = 2 + child_dir_count.
+func TestCreateFSDirNlink(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	if err := fsys.Mkdir("/parent", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Mkdir("/parent/child1", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Mkdir("/parent/child2", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := fsys.Create("/parent/file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	st := erofstest.Stat(t, efs, "parent")
+	// nlink should be 2 (self + parent) + 2 (child dirs) = 4
+	if st.Nlink != 4 {
+		t.Errorf("parent nlink: got %d, want 4", st.Nlink)
+	}
+}
+
+// TestCreateFSWithTempDir verifies that WithTempDir is respected.
+func TestCreateFSWithTempDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	var buf testBuffer
+	fsys := erofs.Create(&buf, erofs.WithTempDir(tmpDir))
+
+	f, err := fsys.Create("/file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	erofstest.CheckFile(t, efs, "file.txt", "hello")
+}
+
+// TestCreateFSRootMetadata verifies that Mkdir("/") sets root permissions
+// and path-based methods can set metadata on it.
+func TestCreateFSRootMetadata(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	if err := fsys.Mkdir("/", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Chown("/", 1000, 2000); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	st := erofstest.Stat(t, efs, ".")
+	if st.Mode.Perm() != 0o700 {
+		t.Errorf("root perm: got %o, want 700", st.Mode.Perm())
+	}
+	if st.UID != 1000 || st.GID != 2000 {
+		t.Errorf("root uid/gid: got %d/%d, want 1000/2000", st.UID, st.GID)
+	}
+}
+
+// TestCreateFSMultipleFiles tests creating many files to exercise the
+// spool and verify ordering.
+func TestCreateFSMultipleFiles(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	for i := range 100 {
+		f, err := fsys.Create(fmt.Sprintf("/file%03d.txt", i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := fmt.Fprintf(f, "content %d\n", i); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	for i := range 100 {
+		name := fmt.Sprintf("file%03d.txt", i)
+		expected := fmt.Sprintf("content %d\n", i)
+		erofstest.CheckFile(t, efs, name, expected)
+	}
+
+	// Verify directory has all 100 entries.
+	entries, err := fs.ReadDir(efs, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 100 {
+		t.Errorf("got %d entries, want 100", len(entries))
+	}
+}
+
+// TestWriterOpen tests Open and Read for regular files in spool mode.
+func TestWriterOpen(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	f, err := fsys.Create("/hello.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("hello world\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open and read back.
+	rf, err := fsys.Open("/hello.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rf.Close() }()
+
+	got, err := io.ReadAll(rf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello world\n" {
+		t.Errorf("got %q, want %q", got, "hello world\n")
+	}
+}
+
+// TestWriterOpenDataFile tests Open and Read for regular files in data file mode.
+func TestWriterOpenDataFile(t *testing.T) {
+	dataPath := filepath.Join(t.TempDir(), "data.bin")
+	df, err := os.Create(dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = df.Close() }()
+
+	var metaBuf testBuffer
+	fsys := erofs.Create(&metaBuf, erofs.WithDataFile(df))
+
+	f, err := fsys.Create("/hello.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("data file content\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	rf, err := fsys.Open("/hello.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rf.Close() }()
+
+	got, err := io.ReadAll(rf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "data file content\n" {
+		t.Errorf("got %q, want %q", got, "data file content\n")
+	}
+}
+
+// TestWriterOpenEmpty tests Open on an empty file.
+func TestWriterOpenEmpty(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	f, err := fsys.Create("/empty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	rf, err := fsys.Open("/empty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rf.Close() }()
+
+	got, err := io.ReadAll(rf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %d bytes", len(got))
+	}
+}
+
+// TestWriterStat tests Stat for various entry types.
+func TestWriterStat(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	f, err := fsys.Create("/file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("content\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Chmod(0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Chtimes("/file.txt", time.Time{}, time.Unix(1700000000, 123456789)); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Mkdir("/dir", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Symlink("file.txt", "/link"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Mknod("/null", disk.StatTypeChrdev|0o666, 1<<8|3); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stat regular file.
+	fi, err := fsys.Stat("/file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Name() != "file.txt" {
+		t.Errorf("name: got %q, want %q", fi.Name(), "file.txt")
+	}
+	if fi.Size() != 8 {
+		t.Errorf("size: got %d, want 8", fi.Size())
+	}
+	if fi.Mode().Perm() != 0o755 {
+		t.Errorf("mode: got %o, want 755", fi.Mode().Perm())
+	}
+	if !fi.Mode().IsRegular() {
+		t.Errorf("expected regular file mode")
+	}
+	if fi.ModTime() != time.Unix(1700000000, 123456789) {
+		t.Errorf("modtime: got %v, want %v", fi.ModTime(), time.Unix(1700000000, 123456789))
+	}
+
+	// Stat directory.
+	di, err := fsys.Stat("/dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !di.IsDir() {
+		t.Error("expected directory")
+	}
+	if di.Mode().Perm() != 0o700 {
+		t.Errorf("dir mode: got %o, want 700", di.Mode().Perm())
+	}
+
+	// Stat symlink.
+	li, err := fsys.Stat("/link")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if li.Mode().Type() != fs.ModeSymlink {
+		t.Errorf("expected symlink, got %v", li.Mode().Type())
+	}
+
+	// Stat device.
+	ni, err := fsys.Stat("/null")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ni.Mode()&fs.ModeCharDevice == 0 {
+		t.Errorf("expected char device, got %v", ni.Mode())
+	}
+
+	// Stat root.
+	ri, err := fsys.Stat("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ri.IsDir() {
+		t.Error("root: expected directory")
+	}
+	if ri.Name() != "/" {
+		t.Errorf("root name: got %q, want %q", ri.Name(), "/")
+	}
+
+	// Stat not found.
+	_, err = fsys.Stat("/nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent path")
+	}
+}
+
+// TestWriterReadDir tests Open on directories and ReadDir.
+func TestWriterReadDir(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	if err := fsys.Mkdir("/subdir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	f1, err := fsys.Create("/hello.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f1.Write([]byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f1.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	f2, err := fsys.Create("/subdir/nested.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f2.Write([]byte("nested")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f2.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fsys.Symlink("hello.txt", "/link"); err != nil {
+		t.Fatal(err)
+	}
+
+	// ReadDir on root.
+	d, err := fsys.Open("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = d.Close() }()
+
+	rdf, ok := d.(fs.ReadDirFile)
+	if !ok {
+		t.Fatal("root Open did not return ReadDirFile")
+	}
+
+	entries, err := rdf.ReadDir(-1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	want := []string{"hello.txt", "link", "subdir"}
+	if len(names) != len(want) {
+		t.Fatalf("got %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("entry[%d]: got %q, want %q", i, names[i], want[i])
+		}
+	}
+
+	// Verify subdir entry is a directory.
+	for _, e := range entries {
+		if e.Name() == "subdir" && !e.IsDir() {
+			t.Error("subdir should be a directory")
+		}
+	}
+
+	// ReadDir on subdir.
+	sd, err := fsys.Open("/subdir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sd.Close() }()
+
+	sdEntries, err := sd.(fs.ReadDirFile).ReadDir(-1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sdEntries) != 1 || sdEntries[0].Name() != "nested.txt" {
+		t.Errorf("subdir entries: got %v, want [nested.txt]", sdEntries)
+	}
+}
+
+// TestWriterOpenErrors tests error cases for Open.
+func TestWriterOpenErrors(t *testing.T) {
+	t.Run("not found", func(t *testing.T) {
+		var buf testBuffer
+		fsys := erofs.Create(&buf)
+		_, err := fsys.Open("/nonexistent")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("file not yet closed", func(t *testing.T) {
+		var buf testBuffer
+		fsys := erofs.Create(&buf)
+		f, err := fsys.Create("/file.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write([]byte("data")); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = fsys.Open("/file.txt")
+		if err == nil {
+			t.Fatal("expected error opening file still being written")
+		}
+
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Should succeed now.
+		rf, err := fsys.Open("/file.txt")
+		if err != nil {
+			t.Fatal("expected success after file closed:", err)
+		}
+		_ = rf.Close()
+	})
+
+	t.Run("read from dir", func(t *testing.T) {
+		var buf testBuffer
+		fsys := erofs.Create(&buf)
+		if err := fsys.Mkdir("/dir", 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		d, err := fsys.Open("/dir")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = d.Close() }()
+
+		_, err = d.Read(make([]byte, 10))
+		if err == nil {
+			t.Fatal("expected error reading from directory")
+		}
+	})
+}
+
+// TestMetadataOnlyNoFileData verifies that metadata-only images do not
+// contain file data. The EROFS output should hold only inodes, dirents,
+// xattrs, and chunk indexes — never the file content itself.
+func TestMetadataOnlyNoFileData(t *testing.T) {
+	// Use a recognizable, non-trivial pattern that won't appear by coincidence.
+	marker := bytes.Repeat([]byte("EROFS_DATA_LEAK_CHECK!"), 200) // 4400 bytes
+
+	t.Run("MetadataOnly flag", func(t *testing.T) {
+		var meta testBuffer
+		w := erofs.Create(&meta)
+
+		srcFS := fstest.MapFS{
+			"testfile.bin": &fstest.MapFile{Data: marker, Mode: 0o644},
+		}
+		if err := w.CopyFrom(srcFS, erofs.MetadataOnly()); err != nil {
+			t.Fatal("CopyFrom:", err)
+		}
+
+		if err := w.Close(); err != nil {
+			t.Fatal("Close:", err)
+		}
+
+		if bytes.Contains(meta.Bytes(), marker) {
+			t.Error("metadata image contains file data — data leaked into metadata-only output")
+		}
+		t.Logf("metadata size: %d bytes, marker size: %d bytes", len(meta.Bytes()), len(marker))
+	})
+
+	t.Run("WithDataFile", func(t *testing.T) {
+		dataPath := filepath.Join(t.TempDir(), "data.bin")
+		df, err := os.Create(dataPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = df.Close() }()
+
+		var meta testBuffer
+		w := erofs.Create(&meta, erofs.WithDataFile(df))
+
+		f, err := w.Create("/testfile.bin")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write(marker); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := w.Close(); err != nil {
+			t.Fatal("Close:", err)
+		}
+
+		if bytes.Contains(meta.Bytes(), marker) {
+			t.Error("metadata image contains file data — data leaked into metadata-only output")
+		}
+
+		// Data file should contain the file data.
+		dfRead, err := os.ReadFile(dataPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Contains(dfRead, marker) {
+			t.Error("data file does not contain file data")
+		}
+		t.Logf("metadata: %d bytes, data file: %d bytes", len(meta.Bytes()), len(dfRead))
+	})
+
+	t.Run("CopyFrom with pre-existing chunks", func(t *testing.T) {
+		// Simulate a source that provides chunk mappings (like ext4).
+		// The metadata image must not contain file data, and no data
+		// should be written to a data file.
+
+		dataPath := filepath.Join(t.TempDir(), "data.bin")
+		df, err := os.Create(dataPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = df.Close() }()
+
+		var meta testBuffer
+		w := erofs.Create(&meta, erofs.WithDataFile(df))
+
+		// Build a source FS where entries carry pre-existing chunks.
+		srcFS := newChunkedFS(marker)
+
+		if err := w.CopyFrom(srcFS, erofs.MetadataOnly()); err != nil {
+			t.Fatal("CopyFrom:", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal("Close:", err)
+		}
+
+		if bytes.Contains(meta.Bytes(), marker) {
+			t.Error("metadata image contains file data — data leaked into metadata-only output")
+		}
+
+		// Data file should be empty — chunks reference the original device,
+		// so no data should be copied.
+		dfInfo, err := os.Stat(dataPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dfInfo.Size() != 0 {
+			t.Errorf("data file should be empty for pre-existing chunks, got %d bytes", dfInfo.Size())
+		}
+		t.Logf("metadata: %d bytes, data file: %d bytes", len(meta.Bytes()), dfInfo.Size())
+	})
+}
+
+// chunkedFS is a test fs.FS that provides entries with pre-existing chunk
+// mappings and data readers, simulating an ext4-like source.
+type chunkedFS struct {
+	data []byte
+}
+
+func newChunkedFS(data []byte) *chunkedFS {
+	return &chunkedFS{data: data}
+}
+
+func (cfs *chunkedFS) DeviceBlocks() uint64 { return 1024 }
+
+func (cfs *chunkedFS) Open(name string) (fs.File, error) {
+	if name == "." {
+		return &chunkedDir{cfs: cfs}, nil
+	}
+	if name == "testfile.bin" {
+		return &chunkedFile{data: cfs.data}, nil
+	}
+	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+}
+
+type chunkedDir struct {
+	cfs     *chunkedFS
+	didRead bool
+}
+
+func (d *chunkedDir) Stat() (fs.FileInfo, error) {
+	return &chunkedDirInfo{}, nil
+}
+func (d *chunkedDir) Read([]byte) (int, error) {
+	return 0, &fs.PathError{Op: "read", Path: ".", Err: fmt.Errorf("is a directory")}
+}
+func (d *chunkedDir) Close() error { return nil }
+func (d *chunkedDir) ReadDir(n int) ([]fs.DirEntry, error) {
+	if d.didRead {
+		return nil, io.EOF
+	}
+	d.didRead = true
+	return []fs.DirEntry{&chunkedDirEntry{data: d.cfs.data}}, nil
+}
+
+type chunkedDirInfo struct{}
+
+func (i *chunkedDirInfo) Name() string       { return "." }
+func (i *chunkedDirInfo) Size() int64        { return 0 }
+func (i *chunkedDirInfo) Mode() fs.FileMode  { return fs.ModeDir | 0o755 }
+func (i *chunkedDirInfo) ModTime() time.Time { return time.Time{} }
+func (i *chunkedDirInfo) IsDir() bool        { return true }
+func (i *chunkedDirInfo) Sys() any           { return nil }
+
+type chunkedDirEntry struct {
+	data []byte
+}
+
+func (e *chunkedDirEntry) Name() string      { return "testfile.bin" }
+func (e *chunkedDirEntry) IsDir() bool       { return false }
+func (e *chunkedDirEntry) Type() fs.FileMode { return 0 }
+func (e *chunkedDirEntry) Info() (fs.FileInfo, error) {
+	return &chunkedFileInfo{size: int64(len(e.data))}, nil
+}
+
+type chunkedFileInfo struct {
+	size int64
+}
+
+func (i *chunkedFileInfo) Name() string       { return "testfile.bin" }
+func (i *chunkedFileInfo) Size() int64        { return i.size }
+func (i *chunkedFileInfo) Mode() fs.FileMode  { return 0o644 }
+func (i *chunkedFileInfo) ModTime() time.Time { return time.Time{} }
+func (i *chunkedFileInfo) IsDir() bool        { return false }
+func (i *chunkedFileInfo) Sys() any {
+	nblocks := (i.size + 4095) / 4096
+	return &builder.Entry{
+		Nlink: 1,
+		Data:  bytes.NewReader(make([]byte, i.size)),
+		Chunks: []builder.Chunk{{
+			PhysicalBlock: 100,
+			Count:         uint16(nblocks),
+			DeviceID:      1,
+		}},
+	}
+}
+
+type chunkedFile struct {
+	data   []byte
+	offset int
+}
+
+func (f *chunkedFile) Stat() (fs.FileInfo, error) {
+	return &chunkedFileInfo{size: int64(len(f.data))}, nil
+}
+func (f *chunkedFile) Read(p []byte) (int, error) {
+	if f.offset >= len(f.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, f.data[f.offset:])
+	f.offset += n
+	return n, nil
+}
+func (f *chunkedFile) Close() error { return nil }
+
+// --- Merge tests ---
+
+// TestMergeBasic verifies that two CopyFrom calls merge entries.
+func TestMergeBasic(t *testing.T) {
+	base := fstest.MapFS{
+		"file1.txt":     {Data: []byte("base1"), Mode: 0o644},
+		"dir/file2.txt": {Data: []byte("base2"), Mode: 0o644},
+	}
+	overlay := fstest.MapFS{
+		"file3.txt":     {Data: []byte("overlay"), Mode: 0o644},
+		"dir/file4.txt": {Data: []byte("new"), Mode: 0o644},
+	}
+
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	if err := w.CopyFrom(base); err != nil {
+		t.Fatal("CopyFrom base:", err)
+	}
+	if err := w.CopyFrom(overlay, erofs.Merge()); err != nil {
+		t.Fatal("CopyFrom overlay:", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("Open:", err)
+	}
+
+	erofstest.CheckFile(t, efs, "file1.txt", "base1")
+	erofstest.CheckFile(t, efs, "dir/file2.txt", "base2")
+	erofstest.CheckFile(t, efs, "file3.txt", "overlay")
+	erofstest.CheckFile(t, efs, "dir/file4.txt", "new")
+}
+
+// TestMergeWhiteout verifies that .wh.<name> files delete entries.
+func TestMergeWhiteout(t *testing.T) {
+	base := fstest.MapFS{
+		"keep.txt":   {Data: []byte("keep"), Mode: 0o644},
+		"remove.txt": {Data: []byte("gone"), Mode: 0o644},
+		"dir/a.txt":  {Data: []byte("a"), Mode: 0o644},
+	}
+	overlay := fstest.MapFS{
+		".wh.remove.txt": {Data: []byte{}, Mode: 0o644},
+		"dir/.wh.a.txt":  {Data: []byte{}, Mode: 0o644},
+		"dir/b.txt":      {Data: []byte("b"), Mode: 0o644},
+	}
+
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	if err := w.CopyFrom(base); err != nil {
+		t.Fatal("CopyFrom base:", err)
+	}
+	if err := w.CopyFrom(overlay, erofs.Merge()); err != nil {
+		t.Fatal("CopyFrom overlay:", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("Open:", err)
+	}
+
+	erofstest.CheckFile(t, efs, "keep.txt", "keep")
+	erofstest.CheckNotExists(t, efs, "remove.txt")
+	erofstest.CheckNotExists(t, efs, "dir/a.txt")
+	erofstest.CheckFile(t, efs, "dir/b.txt", "b")
+}
+
+// TestMergeOpaque verifies that .wh..wh..opq removes all prior children.
+func TestMergeOpaque(t *testing.T) {
+	base := fstest.MapFS{
+		"dir/old1.txt":     {Data: []byte("old1"), Mode: 0o644},
+		"dir/old2.txt":     {Data: []byte("old2"), Mode: 0o644},
+		"dir/sub/deep.txt": {Data: []byte("deep"), Mode: 0o644},
+	}
+	overlay := fstest.MapFS{
+		"dir/.wh..wh..opq": {Data: []byte{}, Mode: 0o644},
+		"dir/new.txt":      {Data: []byte("new"), Mode: 0o644},
+	}
+
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	if err := w.CopyFrom(base); err != nil {
+		t.Fatal("CopyFrom base:", err)
+	}
+	if err := w.CopyFrom(overlay, erofs.Merge()); err != nil {
+		t.Fatal("CopyFrom overlay:", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("Open:", err)
+	}
+
+	erofstest.CheckNotExists(t, efs, "dir/old1.txt")
+	erofstest.CheckNotExists(t, efs, "dir/old2.txt")
+	erofstest.CheckNotExists(t, efs, "dir/sub/deep.txt")
+	erofstest.CheckFile(t, efs, "dir/new.txt", "new")
+}
+
+// TestMergeOverwrite verifies that overlay files replace base files.
+func TestMergeOverwrite(t *testing.T) {
+	base := fstest.MapFS{
+		"file.txt": {Data: []byte("old"), Mode: 0o644},
+	}
+	overlay := fstest.MapFS{
+		"file.txt": {Data: []byte("new"), Mode: 0o644},
+	}
+
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	if err := w.CopyFrom(base); err != nil {
+		t.Fatal("CopyFrom base:", err)
+	}
+	if err := w.CopyFrom(overlay, erofs.Merge()); err != nil {
+		t.Fatal("CopyFrom overlay:", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("Open:", err)
+	}
+
+	erofstest.CheckFile(t, efs, "file.txt", "new")
+}
+
+// TestMergeWhiteoutDir verifies that a whiteout can remove an entire directory.
+func TestMergeWhiteoutDir(t *testing.T) {
+	base := fstest.MapFS{
+		"dir/file.txt": {Data: []byte("content"), Mode: 0o644},
+	}
+	overlay := fstest.MapFS{
+		".wh.dir": {Data: []byte{}, Mode: 0o644},
+	}
+
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	if err := w.CopyFrom(base); err != nil {
+		t.Fatal("CopyFrom base:", err)
+	}
+	if err := w.CopyFrom(overlay, erofs.Merge()); err != nil {
+		t.Fatal("CopyFrom overlay:", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("Open:", err)
+	}
+
+	erofstest.CheckNotExists(t, efs, "dir")
+	erofstest.CheckNotExists(t, efs, "dir/file.txt")
+}

--- a/mkfs_unix.go
+++ b/mkfs_unix.go
@@ -1,0 +1,30 @@
+//go:build linux
+
+package erofs
+
+import (
+	"io/fs"
+	"syscall"
+
+	"github.com/erofs/go-erofs/internal/builder"
+)
+
+// entryFromSys extracts metadata from info.Sys(). Returns nil if the
+// type is not recognized, allowing the caller to use a default.
+func entryFromSys(info fs.FileInfo) *builder.Entry {
+	switch sys := info.Sys().(type) {
+	case *builder.Entry:
+		return sys
+	case *syscall.Stat_t:
+		return &builder.Entry{
+			UID:     sys.Uid,
+			GID:     sys.Gid,
+			Mtime:   uint64(sys.Mtim.Sec),
+			MtimeNs: uint32(sys.Mtim.Nsec),
+			Nlink:   uint32(sys.Nlink),
+			Rdev:    uint32(sys.Rdev),
+		}
+	default:
+		return nil
+	}
+}

--- a/testbuf_test.go
+++ b/testbuf_test.go
@@ -1,0 +1,51 @@
+package erofs_test
+
+import (
+	"fmt"
+	"io"
+)
+
+// testBuffer is an in-memory io.WriteSeeker for tests.
+type testBuffer struct {
+	buf []byte
+	pos int
+}
+
+func (b *testBuffer) Write(p []byte) (int, error) {
+	end := b.pos + len(p)
+	if end > len(b.buf) {
+		if end > cap(b.buf) {
+			newBuf := make([]byte, end, end*2)
+			copy(newBuf, b.buf)
+			b.buf = newBuf
+		} else {
+			b.buf = b.buf[:end]
+		}
+	}
+	copy(b.buf[b.pos:], p)
+	b.pos = end
+	return len(p), nil
+}
+
+func (b *testBuffer) Seek(offset int64, whence int) (int64, error) {
+	var abs int64
+	switch whence {
+	case io.SeekStart:
+		abs = offset
+	case io.SeekCurrent:
+		abs = int64(b.pos) + offset
+	case io.SeekEnd:
+		abs = int64(len(b.buf)) + offset
+	default:
+		return 0, fmt.Errorf("testbuf: invalid whence %d", whence)
+	}
+	if abs < 0 {
+		return 0, fmt.Errorf("testbuf: negative position %d", abs)
+	}
+	b.pos = int(abs)
+	return abs, nil
+}
+
+func (b *testBuffer) Bytes() []byte {
+	return b.buf
+}

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,673 @@
+package erofs
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sort"
+
+	"github.com/erofs/go-erofs/internal/disk"
+)
+
+// maxBlockSize is the largest block size we support.
+const maxBlockSize = 1 << 20
+
+// onlyWriter wraps an io.Writer to hide io.ReaderFrom so that
+// io.CopyBuffer uses the caller-provided buffer instead of
+// the destination's ReadFrom (which allocates its own).
+type onlyWriter struct{ io.Writer }
+
+// erofsWriter serializes EROFS metadata to an io.Writer.
+type erofsWriter struct {
+	entries     []*erofsEntry // all entries in NID order
+	rootNid     uint64
+	metaBlkAddr uint32
+	totalInodes uint64
+	buildTime   uint64
+	buildTimeNs uint32
+	devices     []uint64 // per-device block counts (one slot per entry)
+	blockSize   int
+	chunkBits   uint8                        // log2(chunkSize / blockSize); chunkSize = blockSize << chunkBits
+	copyBuf     []byte                       // reusable buffer for io.CopyBuffer
+	zeroBuf     []byte                       // blockSize-length zero buffer for padding
+	inodeBuf    [disk.SizeInodeExtended]byte // scratch buffer for writeInode
+}
+
+// inodeSize returns the on-disk inode header size for e.
+func inodeCoreSize(e *erofsEntry) int {
+	if e.compact {
+		return disk.SizeInodeCompact
+	}
+	return disk.SizeInodeExtended
+}
+
+// entryChunkBits returns the chunk bits for a specific entry.
+// Contiguous entries use a larger chunk size to minimize chunk indexes.
+func (w *erofsWriter) entryChunkBits(e *erofsEntry) uint8 {
+	if e.chunkBits > 0 {
+		return e.chunkBits
+	}
+	return w.chunkBits
+}
+
+// entryChunkSize returns the chunk size in bytes for a specific entry.
+func (w *erofsWriter) entryChunkSize(e *erofsEntry) int {
+	return w.blockSize << w.entryChunkBits(e)
+}
+
+// minChunkBits returns the minimum chunkBits such that file size fits in
+// one chunk (chunkSize >= size). Capped at 31 (LayoutChunkFormatBits max).
+func (w *erofsWriter) minChunkBits(size uint64) uint8 {
+	bits := w.chunkBits
+	for uint64(w.blockSize)<<bits < size && bits < 31 {
+		bits++
+	}
+	return bits
+}
+
+func (w *erofsWriter) write(out io.WriteSeeker) error {
+	w.copyBuf = make([]byte, 256*1024) // shared io.CopyBuffer buffer
+	return w.writeSeekable(out)
+}
+
+// writeSeekable uses a data-first on-disk layout: block0 (placeholder),
+// data blocks, metadata. After everything is written, it seeks back to
+// write the real superblock. This matches how mkfs.erofs lays out
+// streaming sources — data is written as it arrives, metadata last.
+func (w *erofsWriter) writeSeekable(out io.WriteSeeker) error {
+	// Data-first layout: sbArea, data blocks, metadata.
+	// Set metaBlkAddr to a sentinel so assignDataBlocks uses data-first.
+	w.metaBlkAddr = 0xFFFFFFFF
+	w.assignDataBlocks()
+
+	// Write placeholder superblock area.
+	if _, err := out.Write(make([]byte, w.sbAreaSize())); err != nil {
+		return err
+	}
+
+	// Stream data blocks directly to output.
+	if err := w.writeDataBlocks(out); err != nil {
+		return err
+	}
+
+	// Buffer and write metadata.
+	meta := w.newMetaBuffer()
+	if err := w.writeMetadataInodes(meta); err != nil {
+		return err
+	}
+	if _, err := meta.WriteTo(out); err != nil {
+		return err
+	}
+
+	// Seek back and write the real block 0 (superblock).
+	if _, err := out.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	return w.writeBlock0(out)
+}
+
+// newMetaBuffer returns a pre-sized bytes.Buffer for metadata serialization.
+func (w *erofsWriter) newMetaBuffer() *bytes.Buffer {
+	totalMetaBytes := 0
+	for _, e := range w.entries {
+		isz := disk.SizeInodeExtended
+		if e.compact {
+			isz = disk.SizeInodeCompact
+		}
+		sz := isz + e.xattrSize + e.trailingSize
+		if sz%32 != 0 {
+			sz = (sz + 31) & ^31
+		}
+		totalMetaBytes += sz
+	}
+	// SB area + metadata padded to block boundary.
+	capacity := w.blockSize + ((totalMetaBytes + w.blockSize - 1) & ^(w.blockSize - 1))
+	buf := bytes.NewBuffer(make([]byte, 0, capacity))
+	return buf
+}
+
+// assignDataBlocks assigns data block addresses to flat-plain entries.
+// For metadata-first layout, data follows metadata.
+// For data-first layout, data starts after the superblock area.
+func (w *erofsWriter) assignDataBlocks() {
+	sbBlks := w.sbAreaBlocks()
+	if w.metaBlkAddr == uint32(sbBlks) {
+		// Metadata-first: data blocks come after metadata.
+		totalMetaBytes := 0
+		for _, e := range w.entries {
+			expectedOff := int(e.nid) * 32
+			sz := inodeCoreSize(e) + e.xattrSize + e.trailingSize
+			if sz%32 != 0 {
+				sz = (sz + 31) & ^31
+			}
+			end := expectedOff + sz
+			if end > totalMetaBytes {
+				totalMetaBytes = end
+			}
+		}
+		metaBlocks := (totalMetaBytes + w.blockSize - 1) / w.blockSize
+		addr := uint32(w.sbAreaBlocks() + metaBlocks)
+		for _, e := range w.entries {
+			if ds := w.flatPlainDataSize(e); ds > 0 {
+				e.dataBlkAddr = addr
+				addr += uint32((ds + w.blockSize - 1) / w.blockSize)
+			}
+		}
+	} else {
+		// Data-first: data starts after superblock area.
+		addr := uint32(w.sbAreaBlocks())
+		for _, e := range w.entries {
+			if ds := w.flatPlainDataSize(e); ds > 0 {
+				e.dataBlkAddr = addr
+				addr += uint32((ds + w.blockSize - 1) / w.blockSize)
+			}
+		}
+		w.metaBlkAddr = addr // metadata follows data
+	}
+}
+
+// sbAreaSize returns the number of bytes needed for the superblock area
+// (blocks before metadata): 1024-byte pad + superblock + device slots,
+// rounded up to block boundary.
+func (w *erofsWriter) sbAreaSize() int {
+	n := disk.SuperBlockOffset + disk.SizeSuperBlock
+	if len(w.devices) > 0 {
+		n += len(w.devices) * disk.SizeDeviceSlot
+	}
+	return ((n + w.blockSize - 1) / w.blockSize) * w.blockSize
+}
+
+// sbAreaBlocks returns the number of blocks occupied by the superblock area.
+func (w *erofsWriter) sbAreaBlocks() int {
+	return w.sbAreaSize() / w.blockSize
+}
+
+// metadataBytes computes the total size of the metadata area, including
+// any zero-padding inserted to reach each inode's expected offset (NID * 32)
+// and rounding each entry up to a 32-byte boundary.
+func (w *erofsWriter) metadataBytes() int {
+	curOff := 0
+	for _, e := range w.entries {
+		expectedOff := int(e.nid) * 32
+		if curOff < expectedOff {
+			curOff = expectedOff
+		}
+		sz := inodeCoreSize(e) + e.xattrSize + e.trailingSize
+		if rem := sz % 32; rem != 0 {
+			sz += 32 - rem
+		}
+		curOff += sz
+	}
+	return curOff
+}
+
+func (w *erofsWriter) writeBlock0(buf io.Writer) error {
+	sbArea := make([]byte, w.sbAreaSize())
+
+	totalMetaBytes := w.metadataBytes()
+	metaBlocks := (totalMetaBytes + w.blockSize - 1) / w.blockSize
+
+	// Count data blocks.
+	dataBlocks := 0
+	for _, e := range w.entries {
+		if ds := w.flatPlainDataSize(e); ds > 0 {
+			dataBlocks += (ds + w.blockSize - 1) / w.blockSize
+		}
+	}
+	totalBlocks := w.sbAreaBlocks() + metaBlocks + dataBlocks
+
+	var featureIncompat uint32
+	var extraDevices uint16
+	var devtSlotOff uint16
+
+	if len(w.devices) > 0 {
+		featureIncompat |= disk.FeatureIncompatDeviceTable
+		extraDevices = uint16(len(w.devices))
+		devtSlotOff = uint16(disk.SizeSuperBlock / 16)
+	}
+	for _, e := range w.entries {
+		if len(e.chunks) > 0 {
+			featureIncompat |= disk.FeatureIncompatChunkedFile
+			break
+		}
+	}
+
+	sb := disk.SuperBlock{
+		MagicNumber:     disk.MagicNumber,
+		BlkSizeBits:     blkBits(w.blockSize),
+		RootNid:         uint16(w.rootNid),
+		Inos:            w.totalInodes,
+		BuildTime:       w.buildTime,
+		BuildTimeNs:     w.buildTimeNs,
+		Blocks:          uint32(totalBlocks),
+		MetaBlkAddr:     w.metaBlkAddr,
+		FeatureIncompat: featureIncompat,
+		ExtraDevices:    extraDevices,
+		DevtSlotOff:     devtSlotOff,
+	}
+
+	sbBuf := &bytes.Buffer{}
+	if err := binary.Write(sbBuf, binary.LittleEndian, &sb); err != nil {
+		return fmt.Errorf("write superblock: %w", err)
+	}
+	copy(sbArea[disk.SuperBlockOffset:], sbBuf.Bytes())
+
+	// Write device slots right after superblock.
+	for i, blocks := range w.devices {
+		if blocks > math.MaxUint32 {
+			return fmt.Errorf("device %d block count %d exceeds 32-bit limit", i+1, blocks)
+		}
+		devSlot := disk.DeviceSlot{
+			Blocks: uint32(blocks),
+		}
+		devBuf := &bytes.Buffer{}
+		if err := binary.Write(devBuf, binary.LittleEndian, &devSlot); err != nil {
+			return fmt.Errorf("write device slot: %w", err)
+		}
+		off := disk.SuperBlockOffset + disk.SizeSuperBlock + i*disk.SizeDeviceSlot
+		copy(sbArea[off:], devBuf.Bytes())
+	}
+
+	_, err := buf.Write(sbArea)
+	return err
+}
+
+// writeMetadataInodes writes inode metadata. Data block addresses must
+// already be assigned on each entry before calling this method.
+func (w *erofsWriter) writeMetadataInodes(buf io.Writer) error {
+	metaStart := 0
+	for _, e := range w.entries {
+		expectedOff := int(e.nid) * 32
+		if expectedOff > metaStart {
+			if _, err := buf.Write(w.zeroBuf[:expectedOff-metaStart]); err != nil {
+				return err
+			}
+			metaStart = expectedOff
+		}
+
+		if err := w.writeInode(buf, e); err != nil {
+			return fmt.Errorf("write inode for %s: %w", e.path, err)
+		}
+		if e.compact {
+			metaStart += disk.SizeInodeCompact
+		} else {
+			metaStart += disk.SizeInodeExtended
+		}
+
+		// Write xattr area
+		if e.xattrSize > 0 {
+			if err := w.writeXattrs(buf, e); err != nil {
+				return fmt.Errorf("write xattrs for %s: %w", e.path, err)
+			}
+			metaStart += e.xattrSize
+		}
+
+		// Write trailing data
+		switch e.mode & disk.StatTypeMask {
+		case disk.StatTypeReg:
+			if e.layout == disk.LayoutChunkBased && (e.size > 0 || len(e.chunks) > 0) {
+				if err := w.writeChunkIndexes(buf, e); err != nil {
+					return fmt.Errorf("write chunks for %s: %w", e.path, err)
+				}
+				metaStart += e.trailingSize
+			} else if e.layout == disk.LayoutFlatInline && e.size > 0 && e.data != nil {
+				n, err := io.CopyBuffer(onlyWriter{buf}, io.LimitReader(e.data, int64(e.size)), w.copyBuf)
+				if c, ok := e.data.(io.Closer); ok {
+					_ = c.Close()
+				}
+				if err != nil {
+					return fmt.Errorf("write inline data for %s: %w", e.path, err)
+				}
+				metaStart += int(n)
+			}
+		case disk.StatTypeDir:
+			if e.layout == disk.LayoutFlatInline {
+				n, err := w.writeDirents(buf, e)
+				if err != nil {
+					return fmt.Errorf("write dirents for %s: %w", e.path, err)
+				}
+				metaStart += n
+			}
+		case disk.StatTypeSymlink:
+			if e.layout == disk.LayoutFlatInline {
+				if _, err := io.WriteString(buf, e.symTarget); err != nil {
+					return fmt.Errorf("write symlink for %s: %w", e.path, err)
+				}
+				metaStart += len(e.symTarget)
+			}
+		}
+
+		// Pad to 32-byte boundary
+		inodeSize := disk.SizeInodeExtended
+		if e.compact {
+			inodeSize = disk.SizeInodeCompact
+		}
+		totalWritten := inodeSize + e.xattrSize + e.trailingSize
+		if totalWritten%32 != 0 {
+			padSize := 32 - (totalWritten % 32)
+			if _, err := buf.Write(w.zeroBuf[:padSize]); err != nil {
+				return err
+			}
+			metaStart += padSize
+		}
+	}
+
+	// Pad metadata to full block boundary
+	if metaStart%w.blockSize != 0 {
+		padSize := w.blockSize - (metaStart % w.blockSize)
+		if _, err := buf.Write(w.zeroBuf[:padSize]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (w *erofsWriter) writeInode(buf io.Writer, e *erofsEntry) error {
+	var inodeData uint32
+
+	switch e.mode & disk.StatTypeMask {
+	case disk.StatTypeReg:
+		if e.layout == disk.LayoutChunkBased {
+			inodeData = disk.LayoutChunkFormatIndexes | uint32(w.entryChunkBits(e))
+		} else if e.layout == disk.LayoutFlatPlain && e.size > 0 {
+			inodeData = e.dataBlkAddr
+		}
+	case disk.StatTypeDir, disk.StatTypeSymlink:
+		if e.layout == disk.LayoutFlatPlain {
+			inodeData = e.dataBlkAddr
+		}
+	case disk.StatTypeChrdev, disk.StatTypeBlkdev, disk.StatTypeFifo, disk.StatTypeSock:
+		inodeData = e.rdev
+	}
+
+	fileSize := e.size
+	switch e.mode & disk.StatTypeMask {
+	case disk.StatTypeDir:
+		fileSize = uint64(w.direntDataSize(e))
+	case disk.StatTypeSymlink:
+		fileSize = uint64(len(e.symTarget))
+	}
+
+	b := &w.inodeBuf
+	clear(b[:])
+
+	if e.compact {
+		binary.LittleEndian.PutUint16(b[0:2], inodeFormat(e.layout, true))
+		binary.LittleEndian.PutUint16(b[2:4], xattrCount(e.xattrSize))
+		binary.LittleEndian.PutUint16(b[4:6], e.mode)
+		binary.LittleEndian.PutUint16(b[6:8], uint16(e.nlink))
+		binary.LittleEndian.PutUint32(b[8:12], uint32(fileSize))
+		binary.LittleEndian.PutUint32(b[16:20], inodeData)
+		binary.LittleEndian.PutUint16(b[24:26], uint16(e.uid))
+		binary.LittleEndian.PutUint16(b[26:28], uint16(e.gid))
+		_, err := buf.Write(b[:disk.SizeInodeCompact])
+		return err
+	}
+
+	binary.LittleEndian.PutUint16(b[0:2], inodeFormat(e.layout, false))
+	binary.LittleEndian.PutUint16(b[2:4], xattrCount(e.xattrSize))
+	binary.LittleEndian.PutUint16(b[4:6], e.mode)
+	binary.LittleEndian.PutUint64(b[8:16], fileSize)
+	binary.LittleEndian.PutUint32(b[16:20], inodeData)
+	binary.LittleEndian.PutUint32(b[24:28], e.uid)
+	binary.LittleEndian.PutUint32(b[28:32], e.gid)
+	binary.LittleEndian.PutUint64(b[32:40], e.mtime)
+	binary.LittleEndian.PutUint32(b[40:44], e.mtimeNs)
+	binary.LittleEndian.PutUint32(b[44:48], e.nlink)
+	_, err := buf.Write(b[:disk.SizeInodeExtended])
+	return err
+}
+
+func (w *erofsWriter) writeXattrs(buf io.Writer, e *erofsEntry) error {
+	// XattrHeader: 4-byte name filter + 1-byte shared count + 7 reserved = 12 bytes
+	var xhdr [12]byte
+	binary.LittleEndian.PutUint32(xhdr[0:4], 0xFFFFFFFF) // name filter unused
+	if _, err := buf.Write(xhdr[:]); err != nil {
+		return err
+	}
+
+	for _, name := range sortedXattrKeys(e.xattrs) {
+		value := e.xattrs[name]
+		nameIndex, suffix := xattrSplit(name)
+
+		var xent [disk.SizeXattrEntry]byte
+		xent[0] = uint8(len(suffix))
+		xent[1] = nameIndex
+		binary.LittleEndian.PutUint16(xent[2:4], uint16(len(value)))
+		if _, err := buf.Write(xent[:]); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(buf, suffix); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(buf, value); err != nil {
+			return err
+		}
+
+		// Pad to 4-byte boundary
+		entryLen := disk.SizeXattrEntry + len(suffix) + len(value)
+		if entryLen%4 != 0 {
+			if _, err := buf.Write(w.zeroBuf[:4-entryLen%4]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// writeChunkIndexes writes chunk index entries for a regular file.
+// Each index entry covers one logical chunk (chunkSize bytes).
+func (w *erofsWriter) writeChunkIndexes(buf io.Writer, e *erofsEntry) error {
+	cs := w.entryChunkSize(e)
+	blocksPerChunk := cs / w.blockSize
+	nchunks := (int(e.size) + cs - 1) / cs
+
+	// Null chunk index (no mapping): StartBlkHi=0xFFFF, DeviceID=0, StartBlkLo=NullAddr.
+	var nullIdx [disk.SizeChunkIndex]byte
+	binary.LittleEndian.PutUint16(nullIdx[0:2], 0xFFFF)
+	binary.LittleEndian.PutUint32(nullIdx[4:8], nullAddr)
+
+	if len(e.chunks) > 0 {
+		// Walk source chunks and emit one index per logical chunk.
+		// Source chunks use block-granularity counts; we step by blocksPerChunk.
+		var scratch [disk.SizeChunkIndex]byte
+		ci := 0   // index into source chunks
+		coff := 0 // block offset within current source chunk
+		for n := 0; n < nchunks; n++ {
+			if ci >= len(e.chunks) {
+				if _, err := buf.Write(nullIdx[:]); err != nil {
+					return err
+				}
+				continue
+			}
+			c := e.chunks[ci]
+			phys := c.PhysicalBlock + uint64(coff)
+			binary.LittleEndian.PutUint16(scratch[0:2], uint16(phys>>32))
+			binary.LittleEndian.PutUint16(scratch[2:4], c.DeviceID)
+			binary.LittleEndian.PutUint32(scratch[4:8], uint32(phys))
+			if _, err := buf.Write(scratch[:]); err != nil {
+				return err
+			}
+			coff += blocksPerChunk
+			for ci < len(e.chunks) && coff >= int(e.chunks[ci].Count) {
+				coff -= int(e.chunks[ci].Count)
+				ci++
+			}
+		}
+	} else {
+		for n := 0; n < nchunks; n++ {
+			if _, err := buf.Write(nullIdx[:]); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// writeDirents writes EROFS directory entries packed into block-sized chunks.
+func (w *erofsWriter) writeDirents(buf io.Writer, e *erofsEntry) (int, error) {
+	type direntInfo struct {
+		name     string
+		nid      uint64
+		fileType uint8
+	}
+
+	// Build the full entry list including "." and ".." then sort
+	// alphabetically. EROFS requires dirents to be sorted within
+	// each block; "." and ".." are not guaranteed to be first.
+	allEnts := make([]direntInfo, 0, len(e.children)+2)
+	allEnts = append(allEnts, direntInfo{".", e.nid, disk.FileTypeDir})
+	allEnts = append(allEnts, direntInfo{"..", e.parentNid, disk.FileTypeDir})
+	for _, c := range e.children {
+		allEnts = append(allEnts, direntInfo{
+			name:     c.name,
+			nid:      c.nid,
+			fileType: c.erofsFileType,
+		})
+	}
+	sort.Slice(allEnts, func(i, j int) bool {
+		return allEnts[i].name < allEnts[j].name
+	})
+
+	totalWritten := 0
+	i := 0
+	for i < len(allEnts) {
+		// Determine how many entries fit in this block
+		start := i
+		blockUsed := 0
+		nameSize := 0
+		for j := i; j < len(allEnts); j++ {
+			headerSize := (j - start + 1) * disk.SizeDirent
+			nameSize += len(allEnts[j].name)
+			needed := headerSize + nameSize
+			if needed > w.blockSize {
+				break
+			}
+			blockUsed = needed
+			i = j + 1
+		}
+		if i == start {
+			// Single entry too large for a block (shouldn't happen)
+			blockUsed = disk.SizeDirent + len(allEnts[i].name)
+			i++
+		}
+
+		blockEnts := allEnts[start:i]
+		blockHeaderSize := len(blockEnts) * disk.SizeDirent
+
+		// Write dirent headers
+		var scratch [disk.SizeDirent]byte
+		nameOff := uint16(blockHeaderSize)
+		for j, de := range blockEnts {
+			if j > 0 {
+				nameOff += uint16(len(blockEnts[j-1].name))
+			}
+			binary.LittleEndian.PutUint64(scratch[0:8], de.nid)
+			binary.LittleEndian.PutUint16(scratch[8:10], nameOff)
+			scratch[10] = de.fileType
+			scratch[11] = 0
+			if _, err := buf.Write(scratch[:]); err != nil {
+				return totalWritten, err
+			}
+			totalWritten += disk.SizeDirent
+		}
+
+		// Write names
+		for _, de := range blockEnts {
+			n, err := io.WriteString(buf, de.name)
+			if err != nil {
+				return totalWritten, err
+			}
+			totalWritten += n
+		}
+
+		// Pad to block boundary if there are more entries
+		if i < len(allEnts) && blockUsed%w.blockSize != 0 {
+			padSize := w.blockSize - (blockUsed % w.blockSize)
+			if _, err := buf.Write(w.zeroBuf[:padSize]); err != nil {
+				return totalWritten, err
+			}
+			totalWritten += padSize
+		}
+	}
+
+	return totalWritten, nil
+}
+
+// writeDataBlocks writes data blocks for flat-plain entries directly to out.
+func (w *erofsWriter) writeDataBlocks(out io.Writer) error {
+	for _, e := range w.entries {
+		ds := w.flatPlainDataSize(e)
+		if ds == 0 {
+			continue
+		}
+
+		var n int
+		switch e.mode & disk.StatTypeMask {
+		case disk.StatTypeReg:
+			expected := int64(ds)
+			var written int64
+			var err error
+			limited := io.LimitReader(e.data, expected)
+			// Use io.Copy for *os.File sources to enable copy_file_range.
+			if _, ok := e.data.(*os.File); ok {
+				written, err = io.Copy(out, limited)
+			} else {
+				written, err = io.CopyBuffer(onlyWriter{out}, limited, w.copyBuf)
+			}
+			if c, ok := e.data.(io.Closer); ok {
+				_ = c.Close()
+			}
+			if err != nil {
+				return fmt.Errorf("write data for %s: %w", e.path, err)
+			}
+			if written != expected {
+				return fmt.Errorf("write data for %s: short read: got %d bytes, expected %d", e.path, written, expected)
+			}
+			n = int(written)
+		case disk.StatTypeDir:
+			written, err := w.writeDirents(out, e)
+			if err != nil {
+				return fmt.Errorf("write dirents for %s: %w", e.path, err)
+			}
+			n = written
+		case disk.StatTypeSymlink:
+			written, err := io.WriteString(out, e.symTarget)
+			if err != nil {
+				return fmt.Errorf("write symlink data for %s: %w", e.path, err)
+			}
+			n = written
+		}
+
+		if n%w.blockSize != 0 {
+			padSize := w.blockSize - (n % w.blockSize)
+			if _, err := out.Write(w.zeroBuf[:padSize]); err != nil {
+				return fmt.Errorf("write padding for %s: %w", e.path, err)
+			}
+		}
+	}
+	return nil
+}
+
+// flatPlainDataSize returns the data size for a flat-plain entry, or 0.
+func (w *erofsWriter) flatPlainDataSize(e *erofsEntry) int {
+	if e.layout != disk.LayoutFlatPlain {
+		return 0
+	}
+	switch e.mode & disk.StatTypeMask {
+	case disk.StatTypeReg:
+		if e.size > 0 && e.data != nil {
+			return int(e.size)
+		}
+	case disk.StatTypeDir:
+		return w.direntDataSize(e)
+	case disk.StatTypeSymlink:
+		return len(e.symTarget)
+	}
+	return 0
+}


### PR DESCRIPTION
## Summary

Add an EROFS image builder (`Writer`) to the root package with support for creating images from directory trees, tar archives, and any `fs.FS` source.

- **`erofs.Writer`** — programmatic image construction via `Create`/`Mkdir`/`Symlink`/`Mknod`, or bulk copy from any `fs.FS` via `CopyFrom`
- **`CopyFrom` options** — `MetadataOnly()` produces a chunk-indexed EROFS referencing data in the original source; `Merge()` applies overlay whiteout semantics across layers
- **Benchmarks** — comparison matrix against `mkfs.erofs` for dir, tar, and multi-layer merge workloads
- ~~**`tar` sub-package** — `fs.FS` adapter for tar archives with AUFS whiteout-to-overlayfs conversion~~ No longer included in this repository


## Design

`Writer` accepts entries one at a time or in bulk via `CopyFrom(fs.FS)`. Source adapters implement `fs.FS` and optionally expose block size, build time, and device block count through interface assertions.

`MetadataOnly()` mode produces a small EROFS index image with chunk-based layout entries pointing at data in an external blob device — useful for lazy-pulling container images.

`Merge()` mode merges multiple `fs.FS` sources into a single image, converting AUFS `.wh.` markers into overlayfs xattrs.

Data layout uses `copy_file_range` for zero-copy writes from `*os.File` sources. Metadata serialization uses direct byte encoding (no `encoding/binary.Write`) to minimize allocations.

Cross-platform: compiles on Linux, macOS, and Windows. Platform-specific `syscall.Stat_t` handling is in build-tagged files. Tests requiring `mkfs.erofs` or Linux-only syscalls skip when unavailable.

## Benchmark results (250 MB synthetic container layer)

*__Note__* _The tar package is no longer included here, but will be needed for the container use case. Included to show efficiency of the interface._

| Benchmark | Go | mkfs.erofs |
|---|---:|---:|
| Dir / full | 275 ms | 303 ms |
| Tar / full | 272 ms | 449 ms |
| Tar / meta-only | 106 ms | 76 ms |
| Merge (10 layers) | 52 ms | 59 ms |

## Compiled binary size impact (root package)

Measured with `go tool nm -size` on unstripped binaries that import the erofs package.
Sizes reflect linked symbols only — the Go linker dead-strips unused code.

  | Category | Read API | Read + Write API | Delta |
  |----------|----------|------------------|-------|
  | **erofs package** | 3,864 B | 25,127 B | **+21,263 B** |
  | **stdlib** | 945,961 B | 993,309 B | **+47,348 B** |
  | ↳ new: `slices` | — | 7,548 B | +7,548 B |
  | ↳ new: `sort` | — | 4,645 B | +4,645 B |
  | ↳ new: `bytes` | — | 2,647 B | +2,647 B |
  | ↳ new: `runtime` (generics) | — | 2,374 B | +2,374 B |
  | ↳ new: other (`os`, `io`, `cmp`, …) | — | 3,231 B | +3,231 B |
  | ↳ existing: `internal/poll` | 6,041 B | 13,857 B | +7,816 B |
  | ↳ existing: `encoding/binary` | 8,688 B | 15,178 B | +6,490 B |
  | ↳ existing: `os` | 6,350 B | 11,255 B | +4,905 B |
  | ↳ existing: `runtime` | 624,014 B | 626,201 B | +2,187 B |
  | ↳ existing: `io` | 48 B | 2,166 B | +2,118 B |
  | ↳ existing: other | 300,820 B | 304,207 B | +3,387 B |
  | **Unattributed** (type descriptors, GC) | 145,031 B | 154,516 B | **+9,485 B** |
  | **Total (nm)** | **1,094,856 B** | **1,172,952 B** | **+78,096 B (+7.1%)** |


## Test plan

- [x] `go test ./...` passes on Linux
- [x] `go build ./...` compiles on Linux, macOS, Windows
- [x] `go vet ./...` clean on all platforms
- [x] Benchmarks run without errors
- [x] `golangci-lint` clean
- [ ] CI passes on Linux, macOS, Windows
