### PR TITLE
Optimize directory lookup

### DIFF
--- a/erofs.go
+++ b/erofs.go
@@ -910,7 +910,10 @@ func (b *file) Read(p []byte) (int, error) {
 }
 
 func (b *file) Close() error {
-	b.info.cached = nil
+	if b.info != nil && b.info.cached != nil {
+		b.img.putBlock(b.info.cached)
+		b.info.cached = nil
+	}
 	return nil
 }
 

--- a/erofs.go
+++ b/erofs.go
@@ -2,6 +2,7 @@ package erofs
 
 import (
 	"bufio"
+	"bytes"
 	"cmp"
 	"encoding/binary"
 	"errors"
@@ -602,22 +603,12 @@ func (i *image) resolve(op, name string, follow bool) (nid uint64, ftype fs.File
 				ftype: ftype,
 			},
 		}
-		// TODO: Lookup in directory instead of reading all
-		entries, err := d.ReadDir(-1)
+		entNid, entFtype, err := d.lookup(basename)
 		if err != nil {
 			return 0, 0, "", &fs.PathError{Op: op, Path: original, Err: err}
 		}
-		var found bool
-		for _, e := range entries {
-			if e.Name() == basename {
-				nid = e.(*direntry).nid
-				ftype = e.(*direntry).ftype & fs.ModeType
-				found = true
-			}
-		}
-		if !found {
-			return 0, 0, "", &fs.PathError{Op: op, Path: original, Err: fs.ErrNotExist}
-		}
+		nid = entNid
+		ftype = entFtype & fs.ModeType
 
 		// Follow symlinks for intermediate components always,
 		// and for the final component only when follow is true.
@@ -1031,6 +1022,183 @@ func (d *dir) ReadDir(n int) ([]fs.DirEntry, error) {
 	}
 
 	return ents, nil
+}
+
+// lookup searches for a directory entry by name using binary search.
+// EROFS directories are sorted by name both within and across blocks.
+// A cross-block binary search locates the correct block, then an
+// intra-block binary search finds the entry.
+// Returns the nid and file type if found, or fs.ErrNotExist if not.
+func (d *dir) lookup(target string) (uint64, fs.FileMode, error) {
+	fi, err := d.readInfo(false)
+	if err != nil {
+		return 0, 0, fmt.Errorf("readInfo failed: %w", err)
+	}
+
+	targetBytes := []byte(target)
+	blkSize := int64(1 << d.img.sb.BlkSizeBits)
+	nblocks := int((fi.size + blkSize - 1) / blkSize)
+
+	// Binary search across blocks: compare target against the first
+	// entry of each block to find which block may contain the target.
+	// The last loaded block is retained to avoid reloading it for the
+	// intra-block search.
+	var lastBlk *block
+	lastIdx := -1
+	lo, hi := 0, nblocks
+	for lo < hi {
+		mid := lo + (hi-lo)/2
+		pos := int64(mid) * blkSize
+		b, err := d.img.loadBlock(fi, pos)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				hi = mid
+				continue
+			}
+			if lastBlk != nil {
+				d.img.putBlock(lastBlk)
+			}
+			return 0, 0, err
+		}
+		buf := b.bytes()
+		firstName, err := blockFirstName(buf)
+		if err != nil {
+			d.img.putBlock(b)
+			if lastBlk != nil {
+				d.img.putBlock(lastBlk)
+			}
+			return 0, 0, err
+		}
+
+		if bytes.Compare(firstName, targetBytes) <= 0 {
+			// This block's first entry <= target; keep it as candidate.
+			if lastBlk != nil {
+				d.img.putBlock(lastBlk)
+			}
+			lastBlk = b
+			lastIdx = mid
+			lo = mid + 1
+		} else {
+			d.img.putBlock(b)
+			hi = mid
+		}
+	}
+
+	// lastIdx is the last block whose first entry <= target.
+	// The target must be in that block if it exists.
+	if lastIdx < 0 {
+		return 0, 0, fs.ErrNotExist
+	}
+
+	buf := lastBlk.bytes()
+	nid, ftype, err := lookupBlock(buf, targetBytes)
+	d.img.putBlock(lastBlk)
+	return nid, ftype, err
+}
+
+// blockFirstName returns the name of the first entry in a directory block.
+func blockFirstName(buf []byte) ([]byte, error) {
+	if len(buf) < disk.SizeDirent {
+		return nil, fmt.Errorf("directory block too small: %w", ErrInvalid)
+	}
+	var first disk.Dirent
+	if _, err := binary.Decode(buf[:disk.SizeDirent], binary.LittleEndian, &first); err != nil {
+		return nil, fmt.Errorf("decode failed: %w", err)
+	}
+	entryN := first.NameOff / disk.SizeDirent
+	if entryN == 0 || int(first.NameOff) > len(buf) {
+		return nil, fmt.Errorf("invalid name offset %d: %w", first.NameOff, ErrInvalid)
+	}
+	var nameEnd uint16
+	if entryN > 1 {
+		nextOff := int(disk.SizeDirent) + 8
+		if nextOff+2 > len(buf) {
+			return nil, fmt.Errorf("next dirent name offset out of range: %w", ErrInvalid)
+		}
+		nameEnd = binary.LittleEndian.Uint16(buf[nextOff:])
+	} else {
+		nameEnd = uint16(len(buf))
+	}
+	if first.NameOff > nameEnd || int(nameEnd) > len(buf) {
+		return nil, fmt.Errorf("name range [%d:%d] out of bounds: %w", first.NameOff, nameEnd, ErrInvalid)
+	}
+	name := buf[first.NameOff:nameEnd]
+	// Trim NUL terminator if present
+	if i := bytes.IndexByte(name, 0); i >= 0 {
+		name = name[:i]
+	}
+	return name, nil
+}
+
+// blockDirent decodes the dirent at index i from buf and returns the
+// name bytes for that entry. entryN is the total number of entries.
+func blockDirent(buf []byte, i, entryN uint16) (disk.Dirent, []byte, error) {
+	var de disk.Dirent
+	off := int(disk.SizeDirent * i)
+	if off+disk.SizeDirent > len(buf) {
+		return de, nil, fmt.Errorf("dirent %d offset %d out of range: %w", i, off, ErrInvalid)
+	}
+	if _, err := binary.Decode(buf[off:off+disk.SizeDirent], binary.LittleEndian, &de); err != nil {
+		return de, nil, fmt.Errorf("decode dirent %d failed: %w", i, err)
+	}
+	var nameEnd uint16
+	if i < entryN-1 {
+		nextOff := int(disk.SizeDirent*(i+1)) + 8
+		if nextOff+2 > len(buf) {
+			return de, nil, fmt.Errorf("dirent %d next name offset out of range: %w", i, ErrInvalid)
+		}
+		nameEnd = binary.LittleEndian.Uint16(buf[nextOff:])
+	} else {
+		nameEnd = uint16(len(buf))
+	}
+	if de.NameOff > nameEnd || int(nameEnd) > len(buf) {
+		return de, nil, fmt.Errorf("dirent %d name range [%d:%d] out of bounds: %w", i, de.NameOff, nameEnd, ErrInvalid)
+	}
+	name := buf[de.NameOff:nameEnd]
+	// The last entry name may be NUL-terminated before the end of the block.
+	if i == entryN-1 {
+		if j := bytes.IndexByte(name, 0); j >= 0 {
+			name = name[:j]
+		}
+	}
+	return de, name, nil
+}
+
+// lookupBlock searches a single directory block for the target name
+// using binary search.
+func lookupBlock(buf, target []byte) (uint64, fs.FileMode, error) {
+	if len(buf) < disk.SizeDirent {
+		return 0, 0, fmt.Errorf("directory block too small: %w", ErrInvalid)
+	}
+	var first disk.Dirent
+	if _, err := binary.Decode(buf[:disk.SizeDirent], binary.LittleEndian, &first); err != nil {
+		return 0, 0, fmt.Errorf("decode failed: %w", err)
+	}
+	if first.NameOff%disk.SizeDirent != 0 {
+		return 0, 0, fmt.Errorf("invalid name offset %d not aligned to dirent size: %w", first.NameOff, ErrInvalid)
+	}
+	entryN := first.NameOff / disk.SizeDirent
+	if int(first.NameOff) > len(buf) {
+		return 0, 0, fmt.Errorf("name offset %d exceeds block size %d: %w", first.NameOff, len(buf), ErrInvalid)
+	}
+
+	lo, hi := uint16(0), entryN
+	for lo < hi {
+		mid := lo + (hi-lo)/2
+		de, name, err := blockDirent(buf, mid, entryN)
+		if err != nil {
+			return 0, 0, err
+		}
+		switch bytes.Compare(name, target) {
+		case 0:
+			return de.Nid, disk.EroFSFtypeToFileMode(de.FileType), nil
+		case -1:
+			lo = mid + 1
+		default:
+			hi = mid
+		}
+	}
+	return 0, 0, fs.ErrNotExist
 }
 
 type fileInfo struct {

--- a/erofs_test.go
+++ b/erofs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -140,10 +141,10 @@ func BenchmarkLookup(b *testing.B) {
 			for range b.N {
 				f, err := fsys.Open(bc.path)
 				if err != nil {
-					if bc.name == "bigdir-notfound" {
-						continue
+					if !errors.Is(err, fs.ErrNotExist) {
+						b.Fatal(err)
 					}
-					b.Fatal(err)
+					continue
 				}
 				_ = f.Close()
 			}

--- a/erofs_test.go
+++ b/erofs_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/erofs/go-erofs"
 	"github.com/erofs/go-erofs/internal/erofstest"
@@ -94,4 +95,58 @@ func TestErofs(t *testing.T) {
 			t.Fatalf("expected ErrNotImplemented, got %v", err)
 		}
 	})
+}
+
+func BenchmarkLookup(b *testing.B) {
+	if _, err := erofstest.CheckMkfsVersion("1.0"); err != nil {
+		b.Skipf("skipping: %v", err)
+	}
+
+	tc := erofstest.TarContext{}.WithModTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	// Build a tar with directories of varying sizes.
+	lotsOfFiles := make(chan erofstest.WriterToTar)
+	go func() {
+		for i := range 5000 {
+			lotsOfFiles <- tc.File(fmt.Sprintf("/bigdir/%d", i), []byte{}, 0600)
+		}
+		close(lotsOfFiles)
+	}()
+
+	wt := erofstest.TarAll(
+		tc.Dir("/a", 0755),
+		tc.Dir("/a/b", 0755),
+		tc.Dir("/a/b/c", 0755),
+		tc.File("/a/b/c/file.txt", []byte("content\n"), 0644),
+		tc.Dir("/smalldir", 0755),
+		tc.File("/smalldir/file.txt", []byte("content\n"), 0644),
+		tc.Dir("/bigdir", 0755),
+		erofstest.TarStream(lotsOfFiles),
+	)
+
+	fsys := erofstest.MkfsErofs()(b, wt)
+
+	for _, bc := range []struct {
+		name string
+		path string
+	}{
+		{"shallow", "smalldir/file.txt"},
+		{"deep", "a/b/c/file.txt"},
+		{"bigdir-first", "bigdir/0"},
+		{"bigdir-last", "bigdir/4999"},
+		{"bigdir-notfound", "bigdir/nonexistent"},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			for range b.N {
+				f, err := fsys.Open(bc.path)
+				if err != nil {
+					if bc.name == "bigdir-notfound" {
+						continue
+					}
+					b.Fatal(err)
+				}
+				_ = f.Close()
+			}
+		})
+	}
 }

--- a/internal/erofstest/testcase.go
+++ b/internal/erofstest/testcase.go
@@ -273,6 +273,10 @@ var Basic TestCase = &testCase{
 
 		// ReadLink on a regular file should return ErrInvalid.
 		CheckReadLinkFile(t, fsys, "in-root.txt")
+
+		// Close without reading should not panic.
+		CheckOpenClose(t, fsys, "in-root.txt")
+		CheckOpenClose(t, fsys, "usr/lib/testdir")
 	},
 }
 
@@ -764,5 +768,19 @@ func CheckReadLinkFile(t testing.TB, fsys fs.FS, name string) {
 		t.Errorf("ReadLink(%s) should fail on non-symlink", name)
 	} else if !errors.Is(err, fs.ErrInvalid) {
 		t.Errorf("ReadLink(%s): got %v, want fs.ErrInvalid", name, err)
+	}
+}
+
+// CheckOpenClose verifies that opening and immediately closing a file
+// without reading does not panic.
+func CheckOpenClose(t testing.TB, fsys fs.FS, name string) {
+	t.Helper()
+	f, err := fsys.Open(name)
+	if err != nil {
+		t.Errorf("Open(%s): %v", name, err)
+		return
+	}
+	if err := f.Close(); err != nil {
+		t.Errorf("Close(%s): %v", name, err)
 	}
 }


### PR DESCRIPTION
When resolving paths, previously an entire directory would be scanned then iterated through. With this change it is able to directly do the lookup while reading from the blocks. It performs binary search within each block since EROFS directories are sorted by name.

Also fixes a panic when closing a file that was opened but never read.

  ### Benchmark: directory lookup

  ```
  goos: linux
  goarch: amd64
  cpu: Intel(R) Xeon(R) CPU D-1528 @ 1.90GHz
  ```

  #### Time (sec/op)

  | Case | main | this PR | Change |
  |------|------|---------|--------|
  | shallow | 37.20µs | 26.26µs | -29.41% |
  | deep | 72.82µs | 52.05µs | -28.52% |
  | bigdir-first | 4094.9µs | 43.71µs | -98.93% |
  | bigdir-last | 3912.6µs | 41.61µs | -98.94% |
  | bigdir-notfound | 3911.6µs | 39.34µs | -98.99% |
  | **geomean** | **701.4µs** | **39.63µs** | **-94.35%** |

  #### Memory (B/op)

  | Case | main | this PR | Change |
  |------|------|---------|--------|
  | shallow | 16.8Ki | 8.4Ki | -50.30% |
  | deep | 33.4Ki | 16.7Ki | -50.05% |
  | bigdir-first | 659.8Ki | 8.4Ki | -98.73% |
  | bigdir-last | 659.9Ki | 8.4Ki | -98.73% |
  | bigdir-notfound | 659.8Ki | 8.3Ki | -98.74% |
  | **geomean** | **174.4Ki** | **9.6Ki** | **-94.50%** |

  #### Allocations (allocs/op)

  | Case | main | this PR | Change |
  |------|------|---------|--------|
  | shallow | 25 | 8 | -68.00% |
  | deep | 43 | 16 | -62.79% |
  | bigdir-first | 10,065 | 8 | -99.92% |
  | bigdir-last | 10,065 | 8 | -99.92% |
  | bigdir-notfound | 10,064 | 7 | -99.93% |
  | **geomean** | **1,019** | **8.9** | **-99.12%** |


