### PR TITLE
Fix mkfs.erofs uid/gid truncation on Windows

### DIFF
--- a/.github/workflows/mingw-compat-headers/posix_compat.h
+++ b/.github/workflows/mingw-compat-headers/posix_compat.h
@@ -7,6 +7,15 @@
 #include <stdio.h>
 #include <errno.h>
 /*
+ * MinGW-w64 defines uid_t/gid_t as 'short' (signed 16-bit), which
+ * truncates values >= 32768 and sign-extends them when promoted to
+ * 32-bit.  Override with macros so all subsequent code (including
+ * erofs-utils internal structs) sees 32-bit unsigned types, matching
+ * the Linux EROFS on-disk format.
+ */
+#define uid_t unsigned int
+#define gid_t unsigned int
+/*
  * MinGW-w64 honours _FILE_OFFSET_BITS=64 for off_t (making it 64-bit),
  * but does NOT remap lseek/ftruncate to their 64-bit variants the way
  * glibc does on Linux.  Provide the remapping here so every call site

--- a/.github/workflows/patches/erofs-utils/005-windows-tar-uid-gid.patch
+++ b/.github/workflows/patches/erofs-utils/005-windows-tar-uid-gid.patch
@@ -1,0 +1,63 @@
+--- a/include/erofs/tar.h	2026-03-03 16:00:00.000000000 +0000
++++ b/include/erofs/tar.h	2026-04-16 10:48:34.347497841 +0100
+@@ -14,6 +14,8 @@
+ struct erofs_pax_header {
+ 	struct stat st;
+ 	struct list_head xattrs;
++	u32 tar_uid;
++	u32 tar_gid;
+ 	bool use_mtime;
+ 	bool use_size;
+ 	bool use_uid;
+--- a/lib/tar.c	2026-04-16 10:48:34.326257577 +0100
++++ b/lib/tar.c	2026-04-16 10:48:34.355993947 +0100
+@@ -592,6 +592,7 @@
+ 					goto out;
+ 				}
+ 				eh->st.st_uid = lln;
++				eh->tar_uid = (u32)lln;
+ 				eh->use_uid = true;
+ 			} else if (!strncmp(kv, "gid=", sizeof("gid=") - 1)) {
+ 				ret = sscanf(value, "%lld %n", &lln, &n);
+@@ -600,6 +601,7 @@
+ 					goto out;
+ 				}
+ 				eh->st.st_gid = lln;
++				eh->tar_gid = (u32)lln;
+ 				eh->use_gid = true;
+ 			} else if (!strncmp(kv, "SCHILY.xattr.",
+ 				   sizeof("SCHILY.xattr.") - 1)) {
+@@ -960,7 +962,8 @@
+ 	if (eh.use_uid) {
+ 		st.st_uid = eh.st.st_uid;
+ 	} else {
+-		st.st_uid = tarerofs_parsenum(th->uid, sizeof(th->uid));
++		eh.tar_uid = tarerofs_parsenum(th->uid, sizeof(th->uid));
++		st.st_uid = eh.tar_uid;
+ 		if (errno)
+ 			goto invalid_tar;
+ 	}
+@@ -968,7 +971,8 @@
+ 	if (eh.use_gid) {
+ 		st.st_gid = eh.st.st_gid;
+ 	} else {
+-		st.st_gid = tarerofs_parsenum(th->gid, sizeof(th->gid));
++		eh.tar_gid = tarerofs_parsenum(th->gid, sizeof(th->gid));
++		st.st_gid = eh.tar_gid;
+ 		if (errno)
+ 			goto invalid_tar;
+ 	}
+@@ -1125,6 +1129,13 @@
+ 	ret = __erofs_fill_inode(im, inode, &st, eh.path);
+ 	if (ret)
+ 		goto out;
++#ifdef _WIN32
++	/* MinGW struct stat truncates uid_t/gid_t to 16-bit. */
++	if (im->params->fixed_uid == -1)
++		inode->i_uid = eh.tar_uid + im->params->uid_offset;
++	if (im->params->fixed_gid == -1)
++		inode->i_gid = eh.tar_gid + im->params->gid_offset;
++#endif
+ 	inode->i_size = st.st_size;
+ 
+ 	if (!S_ISDIR(inode->i_mode)) {

--- a/erofs_test.go
+++ b/erofs_test.go
@@ -29,6 +29,7 @@ func TestErofs(t *testing.T) {
 	}{
 		{"Basic", erofstest.Basic, nil},
 		{"FileSizes", erofstest.FileSizes, nil},
+		{"UIDGIDValues", erofstest.UIDGIDValues, nil},
 		{"LongXattrs", erofstest.LongXattrs, erofstest.XattrPrefixFlags()},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/erofstest/check.go
+++ b/internal/erofstest/check.go
@@ -85,3 +85,30 @@ func Stat(t testing.TB, fsys fs.FS, name string) *erofs.Stat {
 	}
 	return st
 }
+
+// lstatFS is the interface for Lstat only, without requiring ReadLink.
+type lstatFS interface {
+	Lstat(name string) (fs.FileInfo, error)
+}
+
+// Lstat returns the *erofs.Stat for the named path without following symlinks,
+// or calls t.Fatal if it cannot be obtained.
+func Lstat(t testing.TB, fsys fs.FS, name string) *erofs.Stat {
+	t.Helper()
+
+	lfs, ok := fsys.(lstatFS)
+	if !ok {
+		t.Fatalf("FS does not implement Lstat")
+	}
+
+	fi, err := lfs.Lstat(name)
+	if err != nil {
+		t.Fatalf("lstat %s: %v", name, err)
+	}
+
+	st, ok := fi.Sys().(*erofs.Stat)
+	if !ok {
+		t.Fatalf("%s: expected *erofs.Stat from Sys(), got %T", name, fi.Sys())
+	}
+	return st
+}

--- a/internal/erofstest/testcase.go
+++ b/internal/erofstest/testcase.go
@@ -363,6 +363,66 @@ var LargeFile TestCase = &testCase{
 	},
 }
 
+// uidgidTestValues is the shared set of UID/GID pairs tested by
+// UIDGIDValues. Defined once to avoid drift between tar creation and
+// verification.
+var uidgidTestValues = []struct{ uid, gid int }{
+	{0, 0},
+	{1, 1},
+	{1000, 2000},
+	{65534, 65534}, // nobody/nogroup
+	{65535, 65535}, // max compact inode (uint16)
+	{65536, 65536}, // first extended inode value
+	{100000, 100000},
+	{0, 65536}, // compact UID, extended GID
+	{65536, 0}, // extended UID, compact GID
+	{0x7FFFFFFF, 0x7FFFFFFF},
+}
+
+// UIDGIDValues tests a variety of UID/GID values including boundary values
+// for compact (uint16) and extended (uint32) inodes. Each value is tested
+// on a regular file, directory, and symlink.
+var UIDGIDValues TestCase = &testCase{
+	tar: func() WriterToTar {
+		base := TarContext{}.WithModTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+		var entries []WriterToTar
+		for _, id := range uidgidTestValues {
+			tc := base.WithUIDGID(id.uid, id.gid)
+			prefix := fmt.Sprintf("/id-%d-%d", id.uid, id.gid)
+			entries = append(entries,
+				tc.Dir(prefix, 0755),
+				tc.File(prefix+"/file.txt", []byte("hello"), 0644),
+				tc.Dir(prefix+"/dir", 0755),
+				tc.Symlink("file.txt", prefix+"/link"),
+			)
+		}
+		return TarAll(entries...)
+	},
+	verify: func(t testing.TB, fsys fs.FS) {
+		t.Helper()
+		for _, id := range uidgidTestValues {
+			prefix := fmt.Sprintf("id-%d-%d", id.uid, id.gid)
+			wantUID := uint32(id.uid)
+			wantGID := uint32(id.gid)
+
+			st := Stat(t, fsys, prefix+"/file.txt")
+			if st.UID != wantUID || st.GID != wantGID {
+				t.Errorf("%s/file.txt uid/gid: got %d/%d, want %d/%d", prefix, st.UID, st.GID, wantUID, wantGID)
+			}
+
+			dst := Stat(t, fsys, prefix+"/dir")
+			if dst.UID != wantUID || dst.GID != wantGID {
+				t.Errorf("%s/dir uid/gid: got %d/%d, want %d/%d", prefix, dst.UID, dst.GID, wantUID, wantGID)
+			}
+
+			lst := Lstat(t, fsys, prefix+"/link")
+			if lst.UID != wantUID || lst.GID != wantGID {
+				t.Errorf("%s/link uid/gid: got %d/%d, want %d/%d", prefix, lst.UID, lst.GID, wantUID, wantGID)
+			}
+		}
+	},
+}
+
 // generateContent produces deterministic bytes: each byte is i % 251.
 func generateContent(size int) []byte {
 	data := make([]byte, size)

--- a/mkfs_test.go
+++ b/mkfs_test.go
@@ -1387,3 +1387,92 @@ func TestMergeWhiteoutDir(t *testing.T) {
 	erofstest.CheckNotExists(t, efs, "dir")
 	erofstest.CheckNotExists(t, efs, "dir/file.txt")
 }
+
+// TestCreateFSUIDGID tests a variety of UID/GID values including boundary
+// values for compact (uint16) and extended (uint32) inodes.
+func TestCreateFSUIDGID(t *testing.T) {
+	type uidgid struct {
+		uid, gid int
+	}
+	cases := []uidgid{
+		{0, 0},
+		{1, 1},
+		{1000, 2000},
+		{65534, 65534}, // nobody/nogroup on many systems
+		{65535, 65535}, // max compact inode UID/GID
+		{65536, 65536}, // first value requiring extended inode
+		{100000, 100000},
+		{0, 65536}, // mixed: compact-range UID, extended-range GID
+		{65536, 0}, // mixed: extended-range UID, compact-range GID
+		{0x7FFFFFFF, 0x7FFFFFFF},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("uid%d_gid%d", tc.uid, tc.gid), func(t *testing.T) {
+			var buf testBuffer
+			fsys := erofs.Create(&buf)
+
+			// Test UID/GID on a regular file via File.Chown.
+			f, err := fsys.Create("/file.txt")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := f.Write([]byte("hello")); err != nil {
+				t.Fatal(err)
+			}
+			if err := f.Chown(tc.uid, tc.gid); err != nil {
+				t.Fatal(err)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			// Test UID/GID on a directory via Writer.Chown.
+			if err := fsys.Mkdir("/dir", 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsys.Chown("/dir", tc.uid, tc.gid); err != nil {
+				t.Fatal(err)
+			}
+
+			// Test UID/GID on a symlink.
+			if err := fsys.Symlink("file.txt", "/link"); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsys.Chown("/link", tc.uid, tc.gid); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := fsys.Close(); err != nil {
+				t.Fatal("Close:", err)
+			}
+
+			erofstest.FsckErofsBytes(t, buf.Bytes())
+			efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				t.Fatal("Open:", err)
+			}
+
+			wantUID := uint32(tc.uid)
+			wantGID := uint32(tc.gid)
+
+			// Verify file UID/GID.
+			st := erofstest.Stat(t, efs, "file.txt")
+			if st.UID != wantUID || st.GID != wantGID {
+				t.Errorf("file uid/gid: got %d/%d, want %d/%d", st.UID, st.GID, wantUID, wantGID)
+			}
+
+			// Verify directory UID/GID.
+			dst := erofstest.Stat(t, efs, "dir")
+			if dst.UID != wantUID || dst.GID != wantGID {
+				t.Errorf("dir uid/gid: got %d/%d, want %d/%d", dst.UID, dst.GID, wantUID, wantGID)
+			}
+
+			// Verify symlink UID/GID.
+			lst := erofstest.Lstat(t, efs, "link")
+			if lst.UID != wantUID || lst.GID != wantGID {
+				t.Errorf("symlink uid/gid: got %d/%d, want %d/%d", lst.UID, lst.GID, wantUID, wantGID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add unit tests for uid/gid boundary values (compact and extended inodes)
- Fix MinGW `posix_compat.h` to override `uid_t`/`gid_t` as `unsigned int`
- Add erofs-utils patch (`005-windows-tar-uid-gid`) to fix tar header uid/gid truncation caused by MinGW's 16-bit `struct stat` fields

## Root cause

MinGW-w64 defines `uid_t`/`gid_t` as `short` (signed 16-bit). When `mkfs.erofs` parses tar headers, uid/gid values are stored into `struct stat` fields which truncate and sign-extend values >= 32768. For example uid 65532 becomes 4294967292.

The `posix_compat.h` `#define` fix alone is insufficient because `struct stat` is already defined by system headers before the override takes effect.

The patch stores full-width `u32` values alongside `struct stat` in the tar parsing path and overrides `inode->i_uid`/`i_gid` after `__erofs_fill_inode` on Windows.

## Test plan

- [x] `TestCreateFSUIDGID` passes (pure Go writer path)
- [x] `TestErofs/UIDGIDValues` passes on Windows with patched `mkfs.erofs.exe`
- [x] Full test suite passes with no regressions