### PR TITLE
Fix CopyFrom losing metadata for directories and devices from *Stat sources

### DIFF
--- a/internal/disk/ftypes.go
+++ b/internal/disk/ftypes.go
@@ -30,7 +30,7 @@ func EroFSFtypeToFileMode(ftype uint8) fs.FileMode {
 	case FileTypeDir:
 		return fs.ModeDir
 	case FileTypeChrdev:
-		return fs.ModeCharDevice
+		return fs.ModeDevice | fs.ModeCharDevice
 	case FileTypeBlkdev:
 		return fs.ModeDevice
 	case FileTypeFifo:
@@ -52,7 +52,7 @@ func EroFSModeToGoFileMode(mode uint16) fs.FileMode {
 	case StatTypeDir:
 		m |= fs.ModeDir
 	case StatTypeChrdev:
-		m |= fs.ModeCharDevice
+		m |= fs.ModeDevice | fs.ModeCharDevice
 	case StatTypeBlkdev:
 		m |= fs.ModeDevice
 	case StatTypeFifo:

--- a/internal/erofstest/testcase.go
+++ b/internal/erofstest/testcase.go
@@ -242,8 +242,8 @@ var Basic TestCase = &testCase{
 
 		CheckDevice(t, fsys, "dev/block0", fs.ModeDevice, 1)
 		CheckDevice(t, fsys, "dev/block1", fs.ModeDevice, 0)
-		CheckDevice(t, fsys, "dev/char0", fs.ModeCharDevice, 2)
-		CheckDevice(t, fsys, "dev/char1", fs.ModeCharDevice, 3)
+		CheckDevice(t, fsys, "dev/char0", fs.ModeDevice|fs.ModeCharDevice, 2)
+		CheckDevice(t, fsys, "dev/char1", fs.ModeDevice|fs.ModeCharDevice, 3)
 		CheckDevice(t, fsys, "dev/fifo0", fs.ModeNamedPipe, 0)
 
 		// Symlink targets.

--- a/mkfs.go
+++ b/mkfs.go
@@ -485,11 +485,13 @@ func (fsys *Writer) CopyFrom(src fs.FS, opts ...CopyOpt) error {
 			}
 		}
 
-		// For directories from plain fs.FS, ensure nlink >= 2.
-		if info.Mode().IsDir() && be == nil {
-			be = entryFromSys(info)
+		// For directories, ensure nlink >= 2.
+		if info.Mode().IsDir() {
 			if be == nil {
-				be = &builder.Entry{Nlink: 2}
+				be = entryFromSys(info)
+				if be == nil {
+					be = &builder.Entry{Nlink: 2}
+				}
 			}
 			if be.Nlink < 2 {
 				be.Nlink = 2
@@ -497,6 +499,12 @@ func (fsys *Writer) CopyFrom(src fs.FS, opts ...CopyOpt) error {
 			return fsys.add(p, &entryFileInfo{info: info, sys: be})
 		}
 
+		// General case: devices, fifos, sockets, etc.
+		// Wrap in entryFileInfo when be was extracted from Sys()
+		// so that add() sees the metadata.
+		if be != nil {
+			return fsys.add(p, &entryFileInfo{info: info, sys: be})
+		}
 		return fsys.add(p, info)
 	})
 }

--- a/mkfs_test.go
+++ b/mkfs_test.go
@@ -236,7 +236,7 @@ func TestCreateFSMknod(t *testing.T) {
 		t.Fatal("EroFS:", err)
 	}
 
-	erofstest.CheckDevice(t, efs, "null", fs.ModeCharDevice, 1<<8|3)
+	erofstest.CheckDevice(t, efs, "null", fs.ModeDevice|fs.ModeCharDevice, 1<<8|3)
 	erofstest.CheckDevice(t, efs, "sda", fs.ModeDevice, 8<<8) //nolint:staticcheck // minor=0
 }
 
@@ -1509,11 +1509,24 @@ func TestCopyFromStatSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _ = f.Write([]byte("content"))
-	_ = f.Close()
+	if _, err := f.Write([]byte("content")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 	if err := w.Chown("/mydir/file.txt", 2000, 2000); err != nil {
 		t.Fatal(err)
 	}
+
+	// Add a character device with custom ownership.
+	if err := w.Mknod("/mydir/null", disk.StatTypeChrdev|0o666, 1<<8|3); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Chown("/mydir/null", 3000, 3000); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -1563,5 +1576,15 @@ func TestCopyFromStatSource(t *testing.T) {
 	}
 	if fileSt.GID != 2000 {
 		t.Errorf("file.txt GID = %d, want 2000", fileSt.GID)
+	}
+
+	// Device node metadata must be preserved.
+	erofstest.CheckDevice(t, dstFS, "mydir/null", fs.ModeDevice|fs.ModeCharDevice, 1<<8|3)
+	devSt := erofstest.Stat(t, dstFS, "mydir/null")
+	if devSt.UID != 3000 {
+		t.Errorf("null UID = %d, want 3000", devSt.UID)
+	}
+	if devSt.GID != 3000 {
+		t.Errorf("null GID = %d, want 3000", devSt.GID)
 	}
 }

--- a/mkfs_test.go
+++ b/mkfs_test.go
@@ -1476,3 +1476,92 @@ func TestCreateFSUIDGID(t *testing.T) {
 		})
 	}
 }
+
+// TestCopyFromStatSource verifies that CopyFrom preserves directory xattrs,
+// directory ownership, and file ownership when the source FS returns *Stat
+// from FileInfo.Sys() (the generic/EROFS reader path, not *builder.Entry).
+//
+// Before the fix, CopyFrom fell through to add(p, info) for directories
+// and non-regular entries when be was extracted from *Stat, losing all
+// metadata because entryFromSys does not handle *Stat.
+func TestCopyFromStatSource(t *testing.T) {
+	// Build a source EROFS image with a directory that has xattrs and
+	// custom ownership, plus a file with custom ownership.
+	var srcBuf erofstest.TestBuffer
+	w := erofs.Create(&srcBuf)
+
+	if err := w.Mkdir("/", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Mkdir("/mydir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Setxattr("/mydir", "trusted.overlay.opaque", "y"); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Setxattr("/mydir", "user.custom", "val"); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Chown("/mydir", 1000, 1000); err != nil {
+		t.Fatal(err)
+	}
+	f, err := w.Create("/mydir/file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.Write([]byte("content"))
+	_ = f.Close()
+	if err := w.Chown("/mydir/file.txt", 2000, 2000); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open the source EROFS — Sys() returns *erofs.Stat, not *builder.Entry.
+	srcFS, err := erofs.Open(bytes.NewReader(srcBuf.Bytes()))
+	if err != nil {
+		t.Fatal("open source:", err)
+	}
+
+	// CopyFrom into a new Writer (non-MetadataOnly → uses WalkDir path).
+	var dstBuf erofstest.TestBuffer
+	w2 := erofs.Create(&dstBuf)
+	if err := w2.CopyFrom(srcFS); err != nil {
+		t.Fatal("CopyFrom:", err)
+	}
+	if err := w2.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	// Open the destination and verify metadata survived the round-trip.
+	dstFS, err := erofs.Open(bytes.NewReader(dstBuf.Bytes()))
+	if err != nil {
+		t.Fatal("open dest:", err)
+	}
+
+	// Directory xattrs must be preserved.
+	erofstest.CheckXattrs(t, dstFS, "mydir", map[string]string{
+		"trusted.overlay.opaque": "y",
+		"user.custom":            "val",
+	})
+
+	// Directory ownership must be preserved.
+	dirSt := erofstest.Stat(t, dstFS, "mydir")
+	if dirSt.UID != 1000 {
+		t.Errorf("mydir UID = %d, want 1000", dirSt.UID)
+	}
+	if dirSt.GID != 1000 {
+		t.Errorf("mydir GID = %d, want 1000", dirSt.GID)
+	}
+
+	// File content and ownership must be preserved.
+	erofstest.CheckFile(t, dstFS, "mydir/file.txt", "content")
+	fileSt := erofstest.Stat(t, dstFS, "mydir/file.txt")
+	if fileSt.UID != 2000 {
+		t.Errorf("file.txt UID = %d, want 2000", fileSt.UID)
+	}
+	if fileSt.GID != 2000 {
+		t.Errorf("file.txt GID = %d, want 2000", fileSt.GID)
+	}
+}


### PR DESCRIPTION
When FileInfo.Sys() returns *Stat (e.g. from the EROFS reader), CopyFrom
extracted metadata into a *builder.Entry but only used it for regular files
and symlinks. Directories, device files, fifos, and sockets fell through
to add(p, info) which called entryFromSys on the raw info — and
entryFromSys does not handle *Stat, so UID, GID, xattrs, and rdev were
silently zeroed.

Fix by wrapping info in entryFileInfo for all entry types when be was
extracted, and removing the be==nil guard on the directory path so
directories with *Stat metadata also get proper nlink handling.