### PR TITLE
Add data range interface to give access underlying data

### DIFF
--- a/erofs.go
+++ b/erofs.go
@@ -97,6 +97,22 @@ type Stat struct {
 	Xattrs      map[string]string
 }
 
+// DataRange describes a contiguous region of uncompressed file data in a
+// backing device. It is used exclusively for data that can be referenced
+// by position without transformation — the bytes at [Offset, Offset+Size)
+// in the device are the file's content verbatim.
+//
+// Compressed data should not be represented as a DataRange. When a source
+// FS contains compressed files, it should not implement the dataRanger
+// interface for those files (or return nil). CopyFrom will fall back to
+// reading through Open(), which decompresses transparently, and write the
+// decompressed data into the output image.
+type DataRange struct {
+	Device uint16 // device index (0 for the device assigned by CopyFrom)
+	Offset int64  // byte offset in the device
+	Size   int64  // byte length
+}
+
 type options struct {
 	extraDevices []io.ReaderAt
 }
@@ -1047,12 +1063,94 @@ func (b *file) statInfo() (*fileInfo, error) {
 			return nil, err
 		}
 	}
+	// Build data ranges for regular files.
+	if ino.mode.IsRegular() && ino.size > 0 {
+		fi.dataRanges = b.buildDataRanges(ino)
+	}
 	// Release cached block - stat callers don't need inline data
 	if ino.cached != nil {
 		b.img.putBlock(ino.cached)
 		ino.cached = nil
 	}
 	return fi, nil
+}
+
+// buildDataRanges computes the physical data ranges for a regular file.
+func (b *file) buildDataRanges(ino *inode) []DataRange {
+	blockSize := int64(1 << b.img.sb.BlkSizeBits)
+	switch ino.inodeLayout {
+	case disk.LayoutFlatPlain:
+		dataOffset := int64(ino.inodeData) << b.img.sb.BlkSizeBits
+		return []DataRange{{Device: 0, Offset: dataOffset, Size: ino.size}}
+	case disk.LayoutFlatInline:
+		inodeAddr := b.img.metaStartPos() + int64(ino.nid)*disk.SizeInodeCompact
+		trailingAddr := inodeAddr + ino.flatDataOffset()
+		if ino.size <= blockSize {
+			return []DataRange{{Device: 0, Offset: trailingAddr, Size: ino.size}}
+		}
+		// Multi-block inline: earlier blocks at dataBlkAddr, last block inline.
+		headSize := int64(ino.inodeData) * blockSize
+		tailSize := ino.size - headSize
+		var ranges []DataRange
+		if headSize > 0 {
+			dataOffset := int64(ino.inodeData) << b.img.sb.BlkSizeBits
+			ranges = append(ranges, DataRange{Device: 0, Offset: dataOffset, Size: headSize})
+		}
+		ranges = append(ranges, DataRange{Device: 0, Offset: trailingAddr, Size: tailSize})
+		return ranges
+	case disk.LayoutChunkBased:
+		return b.buildChunkDataRanges(ino)
+	}
+	return nil
+}
+
+// buildChunkDataRanges parses chunk indexes into DataRange entries.
+func (b *file) buildChunkDataRanges(ino *inode) []DataRange {
+	chunkFmt := uint16(ino.inodeData)
+	if chunkFmt&disk.LayoutChunkFormatIndexes == 0 {
+		return nil
+	}
+	chunkBits := b.img.sb.BlkSizeBits + uint8(chunkFmt&disk.LayoutChunkFormatBits)
+	nchunks := int((ino.size-1)>>chunkBits) + 1
+	chunkSize := int64(1) << chunkBits
+
+	inodeStart := b.img.metaStartPos() + int64(ino.nid)*disk.SizeInodeCompact
+	baseOffset := inodeStart + ino.flatDataOffset()
+	if baseOffset%8 != 0 {
+		baseOffset = (baseOffset + 7) & ^int64(7)
+	}
+	needed := int64(nchunks * disk.SizeChunkIndex)
+	idxBuf := make([]byte, needed)
+	if _, err := b.img.meta.ReadAt(idxBuf, baseOffset); err != nil {
+		return nil
+	}
+
+	var ranges []DataRange
+	for i := range nchunks {
+		off := i * disk.SizeChunkIndex
+		blkHi := binary.LittleEndian.Uint16(idxBuf[off : off+2])
+		deviceID := binary.LittleEndian.Uint16(idxBuf[off+2:off+4]) & b.img.deviceIDMask
+		blkLo := binary.LittleEndian.Uint32(idxBuf[off+4 : off+8])
+		if ^blkLo == 0 {
+			continue // null/hole
+		}
+		phys := (uint64(blkHi) << 32) | uint64(blkLo)
+		byteOffset := int64(phys) << b.img.sb.BlkSizeBits
+		size := chunkSize
+		if i == nchunks-1 {
+			size = ino.size - int64(i)*chunkSize
+		}
+		// Merge with previous range if contiguous on same device.
+		if len(ranges) > 0 {
+			prev := &ranges[len(ranges)-1]
+			if prev.Device == deviceID && prev.Offset+prev.Size == byteOffset {
+				prev.Size += size
+				continue
+			}
+		}
+		ranges = append(ranges, DataRange{Device: deviceID, Offset: byteOffset, Size: size})
+	}
+	return ranges
 }
 
 func (b *file) Stat() (fs.FileInfo, error) {
@@ -1454,12 +1552,13 @@ func (ino *inode) flatDataOffset() int64 {
 //
 //	if u, ok := fi.(interface{ UID() uint32 }); ok { uid = u.UID() }
 type fileInfo struct {
-	name    string
-	size    int64
-	mode    fs.FileMode
-	mtime   uint64
-	mtimeNs uint32
-	stat    *Stat
+	name       string
+	size       int64
+	mode       fs.FileMode
+	mtime      uint64
+	mtimeNs    uint32
+	stat       *Stat
+	dataRanges []DataRange
 }
 
 func (fi *fileInfo) Name() string       { return fi.name }
@@ -1473,6 +1572,12 @@ func (fi *fileInfo) GID() uint32        { return fi.stat.GID }
 func (fi *fileInfo) Ino() uint64        { return uint64(fi.stat.Ino) }
 func (fi *fileInfo) Nlink() uint64      { return uint64(fi.stat.Nlink) }
 func (fi *fileInfo) Rdev() uint64       { return uint64(fi.stat.Rdev) }
+
+// DataRange returns the physical data ranges for this file's content.
+// DataRange returns the physical data ranges for this file's uncompressed
+// content. Returns nil for compressed files, directories, symlinks, and
+// other non-regular entries.
+func (fi *fileInfo) DataRange() []DataRange { return fi.dataRanges }
 
 // GetAllXattr returns all extended attributes.
 func (fi *fileInfo) GetAllXattr() map[string]string { return fi.stat.Xattrs }

--- a/erofs.go
+++ b/erofs.go
@@ -97,6 +97,39 @@ type Stat struct {
 	Xattrs      map[string]string
 }
 
+// holeOffset is the sentinel value for DataRange.Offset that marks a hole
+// (a sparse region of zeros) rather than backed device data.
+const holeOffset int64 = -1
+
+// DataRange describes one entry in the complete logical layout of a file's
+// content. A slice of DataRange values returned by [fileInfo.DataRange]
+// covers the file from logical byte 0 to logical byte [fs.FileInfo.Size]-1
+// in order, with no gaps or overlaps.
+//
+// The sum of all Size values in the slice must equal the file size exactly.
+// A slice whose sizes do not sum to the file size is invalid.
+//
+// Each entry is either a data entry or a hole entry:
+//
+//   - A data entry has Offset >= 0. The bytes at [Offset, Offset+Size) in
+//     Device are the file's content verbatim — uncompressed, unreferenced
+//     by transformation.
+//   - A hole entry has Offset == -1. It represents Size bytes of zeros at the
+//     current logical position. Device is ignored for hole entries.
+//
+// Compressed data should not be represented as a DataRange. When a source
+// FS contains compressed files, it should not provide DataRange() []DataRange
+// for those files (or should return nil). In full-image mode CopyFrom will
+// fall back to reading through Open(), which decompresses transparently, and
+// write the decompressed data into the output image. In MetadataOnly mode
+// there is no such fallback: files without DataRange() (or pre-built chunks)
+// are stored as chunk-based inodes with no physical mappings (all holes).
+type DataRange struct {
+	Device uint16 // device index (0 for the device assigned by CopyFrom); ignored for holes
+	Offset int64  // byte offset in the device, or -1 for a hole entry
+	Size   int64  // byte length of this entry
+}
+
 type options struct {
 	extraDevices []io.ReaderAt
 }
@@ -336,7 +369,10 @@ func (img *image) openDirect(ino *inode) io.Reader {
 		if baseOffset%8 != 0 {
 			baseOffset = (baseOffset + 7) & ^int64(7)
 		}
-		needed := int64(nchunks * disk.SizeChunkIndex)
+		needed := int64(nchunks) * int64(disk.SizeChunkIndex)
+		if needed > maxChunkIndexBytes {
+			return nil
+		}
 		idxBuf := make([]byte, needed)
 		if _, err := img.meta.ReadAt(idxBuf, baseOffset); err != nil {
 			return nil
@@ -1047,12 +1083,146 @@ func (b *file) statInfo() (*fileInfo, error) {
 			return nil, err
 		}
 	}
+	// Build data ranges for regular files.
+	// Flat layouts are cheap (no I/O) — compute eagerly.
+	// Chunk-based layout requires a ReadAt on the image; defer until needed.
+	if ino.mode.IsRegular() && ino.size > 0 {
+		if ino.inodeLayout == disk.LayoutChunkBased {
+			// Capture a snapshot of the fields buildChunkDataRanges needs.
+			// We must not capture ino by pointer: the caller may reuse it,
+			// and cached block is released below.
+			inoCopy := *ino
+			inoCopy.cached = nil
+			img := b.img
+			fi.rangesLoader = func() []DataRange {
+				f := &file{img: img}
+				return f.buildChunkDataRanges(&inoCopy)
+			}
+		} else {
+			fi.dataRanges = b.buildDataRanges(ino)
+		}
+	}
 	// Release cached block - stat callers don't need inline data
 	if ino.cached != nil {
 		b.img.putBlock(ino.cached)
 		ino.cached = nil
 	}
 	return fi, nil
+}
+
+// buildDataRanges computes the physical data ranges for a regular file.
+func (b *file) buildDataRanges(ino *inode) []DataRange {
+	blockSize := int64(1 << b.img.sb.BlkSizeBits)
+	switch ino.inodeLayout {
+	case disk.LayoutFlatPlain:
+		dataOffset := int64(ino.inodeData) << b.img.sb.BlkSizeBits
+		return []DataRange{{Device: 0, Offset: dataOffset, Size: ino.size}}
+	case disk.LayoutFlatInline:
+		inodeAddr := b.img.metaStartPos() + int64(ino.nid)*disk.SizeInodeCompact
+		trailingAddr := inodeAddr + ino.flatDataOffset()
+		if ino.size <= blockSize {
+			return []DataRange{{Device: 0, Offset: trailingAddr, Size: ino.size}}
+		}
+		// Multi-block inline: earlier full blocks at dataBlkAddr, last block inline.
+		// headSize is the number of complete blocks before the inline tail, in bytes.
+		// ino.inodeData is the starting block address, not a block count.
+		headSize := ((ino.size - 1) / blockSize) * blockSize
+		tailSize := ino.size - headSize
+		var ranges []DataRange
+		if headSize > 0 {
+			dataOffset := int64(ino.inodeData) << b.img.sb.BlkSizeBits
+			ranges = append(ranges, DataRange{Device: 0, Offset: dataOffset, Size: headSize})
+		}
+		ranges = append(ranges, DataRange{Device: 0, Offset: trailingAddr, Size: tailSize})
+		return ranges
+	case disk.LayoutChunkBased:
+		return b.buildChunkDataRanges(ino)
+	}
+	return nil
+}
+
+// maxChunkIndexBytes is an upper bound on the chunk-index table we will
+// allocate for a single file. 64 MiB covers ~8 M chunks; no real EROFS image
+// should approach this, and it prevents allocation bombs from corrupt images.
+const maxChunkIndexBytes = 64 << 20 // 64 MiB
+
+// buildChunkDataRanges parses chunk indexes into DataRange entries covering
+// the complete logical layout of the file. The returned slice satisfies the
+// DataRange contract: entries are in logical-file order and their sizes sum
+// to ino.size exactly.
+//
+// Null/hole chunks are emitted as DataRange{Offset: -1, Size: ...} entries.
+// Consecutive null chunks coalesce into a single hole entry.
+// Adjacent data chunks that are physically contiguous on the same device
+// merge into one entry. Data chunks never merge across a hole boundary.
+//
+// The final entry (data or hole) has its Size trimmed to the file-tail length
+// so the invariant sum(Size) == ino.size holds precisely.
+func (b *file) buildChunkDataRanges(ino *inode) []DataRange {
+	chunkFmt := uint16(ino.inodeData)
+	if chunkFmt&disk.LayoutChunkFormatIndexes == 0 {
+		return nil
+	}
+	// 48-bit chunk addressing is not yet implemented; the null-chunk sentinel
+	// (blkLo == 0xFFFFFFFF) is only unambiguous in 32-bit address mode.
+	if chunkFmt&disk.LayoutChunkFormat48Bit != 0 {
+		return nil
+	}
+	chunkBits := b.img.sb.BlkSizeBits + uint8(chunkFmt&disk.LayoutChunkFormatBits)
+	nchunks := int((ino.size-1)>>chunkBits) + 1
+	chunkSize := int64(1) << chunkBits
+
+	inodeStart := b.img.metaStartPos() + int64(ino.nid)*disk.SizeInodeCompact
+	baseOffset := inodeStart + ino.flatDataOffset()
+	if baseOffset%8 != 0 {
+		baseOffset = (baseOffset + 7) & ^int64(7)
+	}
+	needed := int64(nchunks) * int64(disk.SizeChunkIndex)
+	if needed > maxChunkIndexBytes {
+		return nil
+	}
+	idxBuf := make([]byte, needed)
+	if _, err := b.img.meta.ReadAt(idxBuf, baseOffset); err != nil {
+		return nil
+	}
+
+	var ranges []DataRange
+	for i := range nchunks {
+		// Size of this logical chunk: full chunkSize for all but the last.
+		size := chunkSize
+		if i == nchunks-1 {
+			size = ino.size - int64(i)*chunkSize
+		}
+
+		off := i * disk.SizeChunkIndex
+		blkLo := binary.LittleEndian.Uint32(idxBuf[off+4 : off+8])
+		if ^blkLo == 0 {
+			// Null/hole chunk: coalesce with a preceding hole if possible.
+			if len(ranges) > 0 && ranges[len(ranges)-1].Offset == holeOffset {
+				ranges[len(ranges)-1].Size += size
+			} else {
+				ranges = append(ranges, DataRange{Offset: holeOffset, Size: size})
+			}
+			continue
+		}
+
+		blkHi := binary.LittleEndian.Uint16(idxBuf[off : off+2])
+		deviceID := binary.LittleEndian.Uint16(idxBuf[off+2:off+4]) & b.img.deviceIDMask
+		phys := (uint64(blkHi) << 32) | uint64(blkLo)
+		byteOffset := int64(phys) << b.img.sb.BlkSizeBits
+
+		// Merge with the previous entry if it is a data range that is
+		// physically contiguous on the same device.
+		if len(ranges) > 0 {
+			prev := &ranges[len(ranges)-1]
+			if prev.Offset != holeOffset && prev.Device == deviceID && prev.Offset+prev.Size == byteOffset {
+				prev.Size += size
+				continue
+			}
+		}
+		ranges = append(ranges, DataRange{Device: deviceID, Offset: byteOffset, Size: size})
+	}
+	return ranges
 }
 
 func (b *file) Stat() (fs.FileInfo, error) {
@@ -1454,12 +1624,21 @@ func (ino *inode) flatDataOffset() int64 {
 //
 //	if u, ok := fi.(interface{ UID() uint32 }); ok { uid = u.UID() }
 type fileInfo struct {
-	name    string
-	size    int64
-	mode    fs.FileMode
-	mtime   uint64
-	mtimeNs uint32
-	stat    *Stat
+	name       string
+	size       int64
+	mode       fs.FileMode
+	mtime      uint64
+	mtimeNs    uint32
+	stat       *Stat
+	dataRanges []DataRange
+
+	// rangesOnce and rangesLoader support lazy computation of data ranges
+	// for chunk-based files (LayoutChunkBased). The loader performs a ReadAt
+	// to parse the chunk index, so it is deferred until the caller actually
+	// calls DataRange(). For flat layouts (FlatPlain, FlatInline), ranges
+	// are computed eagerly at stat time since they require no I/O.
+	rangesOnce   sync.Once
+	rangesLoader func() []DataRange
 }
 
 func (fi *fileInfo) Name() string       { return fi.name }
@@ -1473,6 +1652,18 @@ func (fi *fileInfo) GID() uint32        { return fi.stat.GID }
 func (fi *fileInfo) Ino() uint64        { return uint64(fi.stat.Ino) }
 func (fi *fileInfo) Nlink() uint64      { return uint64(fi.stat.Nlink) }
 func (fi *fileInfo) Rdev() uint64       { return uint64(fi.stat.Rdev) }
+
+// DataRange returns the physical data ranges for this file's uncompressed
+// content. Returns nil for compressed files, directories, symlinks, and
+// other non-regular entries.
+func (fi *fileInfo) DataRange() []DataRange {
+	if fi.rangesLoader != nil {
+		fi.rangesOnce.Do(func() {
+			fi.dataRanges = fi.rangesLoader()
+		})
+	}
+	return fi.dataRanges
+}
 
 // GetAllXattr returns all extended attributes.
 func (fi *fileInfo) GetAllXattr() map[string]string { return fi.stat.Xattrs }

--- a/erofs_test.go
+++ b/erofs_test.go
@@ -1,11 +1,13 @@
 package erofs_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -150,5 +152,195 @@ func BenchmarkLookup(b *testing.B) {
 				_ = f.Close()
 			}
 		})
+	}
+}
+
+// dataRanger is used for type-asserting DataRange() from fs.FileInfo.
+type dataRanger interface {
+	DataRange() []erofs.DataRange
+}
+
+// checkDataRangeCoverage asserts that the DataRange() slices returned by
+// Stat() on name cover exactly fileSize bytes, with all positive sizes.
+func checkDataRangeCoverage(t *testing.T, fsys fs.FS, name string, fileSize int) {
+	t.Helper()
+	f, err := fsys.Open(name)
+	if err != nil {
+		t.Fatalf("Open %s: %v", name, err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Stat %s: %v", name, err)
+	}
+	if info.Size() != int64(fileSize) {
+		t.Fatalf("Size = %d, want %d", info.Size(), fileSize)
+	}
+	// All erofs.fileInfo values implement DataRange(); no type-assert guard needed.
+	dr := info.(dataRanger)
+	ranges := dr.DataRange()
+	if len(ranges) == 0 {
+		t.Fatalf("DataRange() returned nil for non-empty file %s", name)
+	}
+	var total int64
+	for _, r := range ranges {
+		if r.Size <= 0 {
+			t.Errorf("range has non-positive Size %d: %+v", r.Size, r)
+		}
+		total += r.Size
+	}
+	if total != info.Size() {
+		t.Errorf("total DataRange size = %d, want %d; ranges = %+v", total, info.Size(), ranges)
+	}
+}
+
+// TestDataRangeMultiBlockCoverage verifies that DataRange() total size equals
+// the file size for multi-block files across the layouts mkfs.erofs produces.
+//
+// The tar pipeline (all platforms) exercises FlatPlain. The dir-source
+// subtest (non-Windows only) exercises FlatInline multi-block, which is the
+// layout that contained the headSize bug (inodeData treated as block count
+// instead of block address).
+func TestDataRangeMultiBlockCoverage(t *testing.T) {
+	if _, err := erofstest.CheckMkfsVersion("1.0"); err != nil {
+		t.Skipf("skipping: %v", err)
+	}
+
+	const blockSize = 4096
+
+	sizes := []struct {
+		name     string
+		fileSize int
+	}{
+		{"2-block", blockSize + 100},
+		{"3-block", blockSize*2 + 200},
+		{"4-block", blockSize*3 + 50},
+	}
+
+	// tar pipeline: works on all platforms; mkfs.erofs uses -Enoinline_data
+	// so files land in FlatPlain layout (single contiguous range).
+	t.Run("tar-pipeline", func(t *testing.T) {
+		for _, tc := range sizes {
+			t.Run(tc.name, func(t *testing.T) {
+				content := bytes.Repeat([]byte("x"), tc.fileSize)
+				tarCtx := erofstest.TarContext{}
+				wt := erofstest.TarAll(tarCtx.File("/file.bin", content, 0o644))
+				fsys := erofstest.MkfsErofs()(t, wt)
+				checkDataRangeCoverage(t, fsys, "file.bin", tc.fileSize)
+			})
+		}
+	})
+
+	// dir-source pipeline: mkfs.erofs with a directory argument produces
+	// FlatInline layout for files whose tail fits in the inode block, giving
+	// multi-block FlatInline files. This is what the headSize fix targets.
+	// Skipped on Windows because the cross-compiled mkfs.erofs there only
+	// supports --tar input.
+	t.Run("dir-source-flatinline", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("mkfs.erofs directory-source mode not available on Windows")
+		}
+		for _, tc := range sizes {
+			t.Run(tc.name, func(t *testing.T) {
+				dir := t.TempDir()
+				content := bytes.Repeat([]byte("x"), tc.fileSize)
+				if err := os.WriteFile(filepath.Join(dir, "file.bin"), content, 0o644); err != nil {
+					t.Fatal(err)
+				}
+				imgPath := filepath.Join(t.TempDir(), "test.erofs")
+				out, err := exec.Command("mkfs.erofs", imgPath, dir).CombinedOutput()
+				if err != nil {
+					t.Fatalf("mkfs.erofs: %s: %v", out, err)
+				}
+				imgData, err := os.ReadFile(imgPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				fsys, err := erofs.Open(bytes.NewReader(imgData))
+				if err != nil {
+					t.Fatal("Open:", err)
+				}
+				checkDataRangeCoverage(t, fsys, "file.bin", tc.fileSize)
+			})
+		}
+	})
+}
+
+// TestDataRangeSparseChunkBased verifies that DataRange() correctly represents
+// sparse (hole-containing) chunk-based EROFS files.  It uses the existing
+// testdata fixture which contains known sparse files.
+//
+// Invariants checked:
+//   - sum(Size) == info.Size() for every regular file.
+//   - Hole entries have Offset == -1.
+//   - At least one file in the fixture has a hole so we are actually
+//     exercising the hole-emission path in buildChunkDataRanges.
+func TestDataRangeSparseChunkBased(t *testing.T) {
+	// basic-chunk-index.erofs stores file data on a separate blob device.
+	metaData, err := os.ReadFile("testdata/basic-chunk-index.erofs")
+	if err != nil {
+		t.Skipf("skipping: testdata not available: %v", err)
+	}
+	blobData, err := os.ReadFile("testdata/basic-chunk-index-data.erofs")
+	if err != nil {
+		t.Skipf("skipping: testdata blob not available: %v", err)
+	}
+
+	fsys, err := erofs.Open(bytes.NewReader(metaData),
+		erofs.WithExtraDevices(bytes.NewReader(blobData)))
+	if err != nil {
+		t.Fatal("Open:", err)
+	}
+
+	foundHole := false
+	err = fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		f, err := fsys.Open(p)
+		if err != nil {
+			return fmt.Errorf("Open %s: %w", p, err)
+		}
+		defer func() { _ = f.Close() }()
+
+		info, err := f.Stat()
+		if err != nil {
+			return fmt.Errorf("Stat %s: %w", p, err)
+		}
+
+		dr := info.(dataRanger)
+		ranges := dr.DataRange()
+
+		// Every non-empty regular file must have at least one range.
+		if info.Size() > 0 && len(ranges) == 0 {
+			t.Errorf("%s: Size=%d but DataRange() returned nil", p, info.Size())
+			return nil
+		}
+
+		// Invariant: sum(Size) == file size.
+		var total int64
+		for j, r := range ranges {
+			if r.Size <= 0 {
+				t.Errorf("%s: DataRange[%d].Size = %d, want > 0", p, j, r.Size)
+			}
+			total += r.Size
+			if r.Offset == -1 {
+				foundHole = true
+			}
+		}
+		if total != info.Size() {
+			t.Errorf("%s: sum(DataRange.Size) = %d, want %d", p, total, info.Size())
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal("WalkDir:", err)
+	}
+
+	if !foundHole {
+		t.Error("no hole entries found in fixture — buildChunkDataRanges hole path was not exercised")
 	}
 }

--- a/internal/builder/entry.go
+++ b/internal/builder/entry.go
@@ -19,9 +19,16 @@ type Entry struct {
 	MetadataOnly bool      // chunk-based layout even without chunks
 }
 
+// NullPhysicalBlock is the sentinel value for Chunk.PhysicalBlock that marks
+// a hole (a sparse region of zero bytes). It corresponds to the on-disk
+// EROFS null chunk encoding (StartBlkHi=0xFFFF, StartBlkLo=0xFFFFFFFF).
+const NullPhysicalBlock uint64 = ^uint64(0)
+
 // Chunk maps a range of logical blocks to physical blocks on a device.
+// If PhysicalBlock == NullPhysicalBlock the chunk is a hole: Count logical
+// blocks of zeros with no physical backing. DeviceID is ignored for holes.
 type Chunk struct {
-	PhysicalBlock uint64 // physical block address
+	PhysicalBlock uint64 // physical block address, or NullPhysicalBlock for a hole
 	Count         uint16 // number of contiguous blocks
-	DeviceID      uint16 // 0 = primary, 1+ = extra device
+	DeviceID      uint16 // 0 = primary, 1+ = extra device; ignored for holes
 }

--- a/mkfs.go
+++ b/mkfs.go
@@ -435,6 +435,15 @@ func (fsys *Writer) CopyFrom(src fs.FS, opts ...CopyOpt) error {
 						be = &builder.Entry{}
 					}
 				}
+				// Generate chunks from DataRange if available.
+				if len(be.Chunks) == 0 {
+					if dr, ok := info.(dataRanger); ok {
+						if ranges := dr.DataRange(); len(ranges) > 0 {
+							be.Chunks = fsys.chunksFromRanges(ranges)
+							be.Contiguous = len(ranges) == 1
+						}
+					}
+				}
 				return fsys.add(p, &entryFileInfo{info: info, sys: be})
 			}
 			// For EROFS sources, use direct SectionReader (bypasses
@@ -742,6 +751,19 @@ type deviceBlocker interface {
 // readLinker is an interface for filesystems that support reading symlink targets.
 type readLinker interface {
 	ReadLink(name string) (string, error)
+}
+
+// dataRanger may be implemented by fs.FileInfo to provide the physical
+// location of uncompressed file data in backing devices. CopyFrom checks
+// this via type assertion in metadata-only mode to build chunk indexes
+// without requiring the caller to construct internal chunk types.
+//
+// This interface should only be implemented for files whose device data
+// is stored verbatim (uncompressed). For compressed files, return nil or
+// do not implement the interface; CopyFrom will read through Open() which
+// handles decompression transparently.
+type dataRanger interface {
+	DataRange() []DataRange
 }
 
 // --- Internal types ---
@@ -1275,6 +1297,35 @@ func (fsys *Writer) zeroPad() []byte {
 		fsys.padBuf = make([]byte, fsys.resolveBlockSize())
 	}
 	return fsys.padBuf
+}
+
+// chunksFromRanges converts DataRange entries into internal chunk entries.
+// The block size used is the Writer's resolved block size. DataRange.Device
+// values are offset by 1 to produce chunk DeviceIDs: DataRange Device 0
+// becomes chunk DeviceID 1 (the first extra device), matching the EROFS
+// convention where DeviceID 0 is the primary image.
+func (fsys *Writer) chunksFromRanges(ranges []DataRange) []builder.Chunk {
+	blockSize := uint64(fsys.resolveBlockSize())
+	var chunks []builder.Chunk
+	for _, r := range ranges {
+		deviceID := r.Device + 1
+		startBlock := uint64(r.Offset) / blockSize
+		totalBlocks := (uint64(r.Size) + blockSize - 1) / blockSize
+		for totalBlocks > 0 {
+			count := totalBlocks
+			if count > 65535 {
+				count = 65535
+			}
+			chunks = append(chunks, builder.Chunk{
+				PhysicalBlock: startBlock,
+				Count:         uint16(count),
+				DeviceID:      deviceID,
+			})
+			startBlock += count
+			totalBlocks -= count
+		}
+	}
+	return chunks
 }
 
 // ensureSpool lazily creates the spool temp file.

--- a/mkfs.go
+++ b/mkfs.go
@@ -483,6 +483,22 @@ func (fsys *Writer) CopyFrom(src fs.FS, opts ...CopyOpt) error {
 						be = &builder.Entry{}
 					}
 				}
+				// Generate chunks from DataRange if available.
+				if len(be.Chunks) == 0 {
+					if dr, ok := info.(dataRanger); ok {
+						if ranges := dr.DataRange(); len(ranges) > 0 {
+							chunks, err := fsys.chunksFromRanges(ranges, info.Size())
+							if err != nil {
+								return fmt.Errorf("chunksFromRanges %s: %w", p, err)
+							}
+							be.Chunks = chunks
+							// Contiguous: a single non-hole range whose total-size
+							// invariant is satisfied (guaranteed by chunksFromRanges)
+							// means the file is fully covered by one contiguous extent.
+							be.Contiguous = len(ranges) == 1 && ranges[0].Offset != holeOffset
+						}
+					}
+				}
 				return fsys.add(p, &entryFileInfo{info: info, sys: be})
 			}
 			// For EROFS sources, use direct SectionReader (bypasses
@@ -794,6 +810,21 @@ type deviceBlocker interface {
 // readLinker is an interface for filesystems that support reading symlink targets.
 type readLinker interface {
 	ReadLink(name string) (string, error)
+}
+
+// dataRanger may be implemented by fs.FileInfo to provide the physical
+// location of uncompressed file data in backing devices. CopyFrom checks
+// this via type assertion in metadata-only mode to build chunk indexes
+// without requiring the caller to construct internal chunk types.
+//
+// This interface should only be implemented for files whose device data
+// is stored verbatim (uncompressed). For compressed files, return nil or
+// do not implement the interface. In full-image mode CopyFrom then falls
+// back to reading through Open(), which decompresses transparently. In
+// MetadataOnly mode there is no such fallback: the file is stored as a
+// chunk-based inode with no physical mappings (all holes).
+type dataRanger interface {
+	DataRange() []DataRange
 }
 
 // --- Internal types ---
@@ -1327,6 +1358,95 @@ func (fsys *Writer) zeroPad() []byte {
 		fsys.padBuf = make([]byte, fsys.resolveBlockSize())
 	}
 	return fsys.padBuf
+}
+
+// chunksFromRanges converts DataRange entries into internal chunk entries.
+// fileSize is the logical size of the file; the sum of all range Sizes must
+// equal fileSize exactly, or an error is returned.
+//
+// The block size used is the Writer's resolved block size. DataRange.Device
+// values are offset by 1 to produce chunk DeviceIDs: DataRange Device 0
+// becomes chunk DeviceID 1 (the first extra device), matching the EROFS
+// convention where DeviceID 0 is the primary image.
+//
+// Validation rules:
+//   - sum(Size) == fileSize; a mismatch is rejected.
+//   - r.Size > 0 for every entry.
+//   - Hole entries (Offset == -1) emit [builder.NullPhysicalBlock] chunks.
+//     Hole Size must be block-aligned for non-final entries; the final entry
+//     may end mid-block to match the file tail.
+//   - For data entries: r.Offset >= 0 and block-aligned; r.Device == 0.
+//   - For non-final data entries: r.Size must be a multiple of blockSize.
+//     The final entry may have a partial last block to match the file tail.
+func (fsys *Writer) chunksFromRanges(ranges []DataRange, fileSize int64) ([]builder.Chunk, error) {
+	blockSize := uint64(fsys.resolveBlockSize())
+
+	// Validate total coverage first.
+	var total int64
+	for _, r := range ranges {
+		total += r.Size
+	}
+	if total != fileSize {
+		return nil, fmt.Errorf("DataRange total size %d does not match file size %d", total, fileSize)
+	}
+
+	last := len(ranges) - 1
+	var chunks []builder.Chunk
+	for i, r := range ranges {
+		if r.Size <= 0 {
+			return nil, fmt.Errorf("DataRange[%d]: non-positive Size %d", i, r.Size)
+		}
+		// Non-final entries must be block-aligned in size; the final entry may
+		// end mid-block to match the file tail.
+		if i < last && uint64(r.Size)%blockSize != 0 {
+			return nil, fmt.Errorf("DataRange[%d]: non-final Size %d is not block-aligned (block size %d)", i, r.Size, blockSize)
+		}
+		if r.Offset == holeOffset {
+			// Hole: emit NullPhysicalBlock chunks covering the hole span.
+			totalBlocks := (uint64(r.Size) + blockSize - 1) / blockSize
+			for totalBlocks > 0 {
+				count := totalBlocks
+				if count > 65535 {
+					count = 65535
+				}
+				chunks = append(chunks, builder.Chunk{
+					PhysicalBlock: builder.NullPhysicalBlock,
+					Count:         uint16(count),
+				})
+				totalBlocks -= count
+			}
+			continue
+		}
+		if r.Offset < 0 {
+			return nil, fmt.Errorf("DataRange[%d]: negative Offset %d", i, r.Offset)
+		}
+		if uint64(r.Offset)%blockSize != 0 {
+			return nil, fmt.Errorf("DataRange[%d]: Offset %d is not block-aligned (block size %d)", i, r.Offset, blockSize)
+		}
+		// Non-EROFS sources register exactly one device via DeviceBlocks();
+		// only Device=0 is valid. Device=0xFFFF would also wrap deviceID to 0
+		// (the primary image), producing an invalid mapping.
+		if r.Device != 0 {
+			return nil, fmt.Errorf("DataRange[%d]: Device %d out of range (source declared one device, only Device=0 is valid)", i, r.Device)
+		}
+		deviceID := r.Device + 1
+		startBlock := uint64(r.Offset) / blockSize
+		totalBlocks := (uint64(r.Size) + blockSize - 1) / blockSize
+		for totalBlocks > 0 {
+			count := totalBlocks
+			if count > 65535 {
+				count = 65535
+			}
+			chunks = append(chunks, builder.Chunk{
+				PhysicalBlock: startBlock,
+				Count:         uint16(count),
+				DeviceID:      deviceID,
+			})
+			startBlock += count
+			totalBlocks -= count
+		}
+	}
+	return chunks, nil
 }
 
 // ensureSpool lazily creates the spool temp file.

--- a/mkfs_test.go
+++ b/mkfs_test.go
@@ -1740,3 +1740,474 @@ func TestCopyFromStatSource(t *testing.T) {
 		t.Errorf("null GID = %d, want 3000", devSt.GID)
 	}
 }
+
+// --- DataRange-driven CopyFrom tests ---
+
+// dataRangerFileInfo is a test fs.FileInfo whose DataRange() returns
+// caller-supplied ranges, simulating a source (e.g. ext4 or OCI layer
+// reader) that knows where its file bytes live without holding a data reader.
+// content is the data returned by Read(); if nil, Read returns zeros.
+type dataRangerFileInfo struct {
+	name    string
+	size    int64
+	ranges  []erofs.DataRange
+	content []byte // data served by Read(); nil means return zeros
+}
+
+func (fi *dataRangerFileInfo) Name() string                 { return fi.name }
+func (fi *dataRangerFileInfo) Size() int64                  { return fi.size }
+func (fi *dataRangerFileInfo) Mode() fs.FileMode            { return 0o644 }
+func (fi *dataRangerFileInfo) ModTime() time.Time           { return time.Time{} }
+func (fi *dataRangerFileInfo) IsDir() bool                  { return false }
+func (fi *dataRangerFileInfo) Sys() any                     { return nil }
+func (fi *dataRangerFileInfo) DataRange() []erofs.DataRange { return fi.ranges }
+
+// dataRangerFS is a minimal fs.FS that exposes one regular file whose
+// FileInfo implements DataRange().  It also implements DeviceBlocks() so
+// CopyFrom records the backing-device size.
+type dataRangerFS struct {
+	file *dataRangerFileInfo
+	// deviceBlocks is the declared size (in 4096-byte blocks) of the backing device.
+	deviceBlocks uint64
+}
+
+func (f *dataRangerFS) DeviceBlocks() uint64 { return f.deviceBlocks }
+
+func (f *dataRangerFS) Open(name string) (fs.File, error) {
+	if name == "." {
+		return &dataRangerDir{fs: f}, nil
+	}
+	if name == f.file.name {
+		return &dataRangerFile{info: f.file}, nil
+	}
+	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+}
+
+type dataRangerDir struct {
+	fs      *dataRangerFS
+	didRead bool
+}
+
+func (d *dataRangerDir) Stat() (fs.FileInfo, error) {
+	return &dataRangerDirInfo{}, nil
+}
+func (d *dataRangerDir) Read([]byte) (int, error) {
+	return 0, &fs.PathError{Op: "read", Path: ".", Err: fmt.Errorf("is a directory")}
+}
+func (d *dataRangerDir) Close() error { return nil }
+func (d *dataRangerDir) ReadDir(n int) ([]fs.DirEntry, error) {
+	if d.didRead {
+		return nil, io.EOF
+	}
+	d.didRead = true
+	return []fs.DirEntry{&dataRangerEntry{info: d.fs.file}}, nil
+}
+
+type dataRangerDirInfo struct{}
+
+func (i *dataRangerDirInfo) Name() string       { return "." }
+func (i *dataRangerDirInfo) Size() int64        { return 0 }
+func (i *dataRangerDirInfo) Mode() fs.FileMode  { return fs.ModeDir | 0o755 }
+func (i *dataRangerDirInfo) ModTime() time.Time { return time.Time{} }
+func (i *dataRangerDirInfo) IsDir() bool        { return true }
+func (i *dataRangerDirInfo) Sys() any           { return nil }
+
+type dataRangerEntry struct{ info *dataRangerFileInfo }
+
+func (e *dataRangerEntry) Name() string               { return e.info.name }
+func (e *dataRangerEntry) IsDir() bool                { return false }
+func (e *dataRangerEntry) Type() fs.FileMode          { return 0 }
+func (e *dataRangerEntry) Info() (fs.FileInfo, error) { return e.info, nil }
+
+type dataRangerFile struct {
+	info   *dataRangerFileInfo
+	offset int64
+}
+
+func (f *dataRangerFile) Stat() (fs.FileInfo, error) { return f.info, nil }
+func (f *dataRangerFile) Read(p []byte) (int, error) {
+	if f.offset >= f.info.size {
+		return 0, io.EOF
+	}
+	var n int
+	if f.info.content != nil {
+		// Serve actual content so leak-detection tests can catch accidental reads.
+		n = copy(p, f.info.content[f.offset:])
+	} else {
+		// No content supplied: return zeros up to size.
+		end := f.info.size - f.offset
+		if int64(len(p)) < end {
+			end = int64(len(p))
+		}
+		for i := range p[:end] {
+			p[i] = 0
+		}
+		n = int(end)
+	}
+	f.offset += int64(n)
+	return n, nil
+}
+func (f *dataRangerFile) Close() error { return nil }
+
+// TestCopyFromDataRange verifies that CopyFrom(MetadataOnly) uses the
+// DataRange() accessor from a source FileInfo to synthesise chunk indexes
+// in the output EROFS image, and that the resulting image is valid.
+//
+// It also verifies that chunksFromRanges rejects invalid inputs (negative
+// offsets, non-positive sizes, unaligned offsets).
+func TestCopyFromDataRange(t *testing.T) {
+	const blockSize = 4096
+
+	t.Run("single contiguous range", func(t *testing.T) {
+		// One file, two blocks starting at physical block 10 on device 0.
+		src := &dataRangerFS{
+			deviceBlocks: 1024,
+			file: &dataRangerFileInfo{
+				name: "data.bin",
+				size: blockSize * 2,
+				ranges: []erofs.DataRange{
+					{Device: 0, Offset: blockSize * 10, Size: blockSize * 2},
+				},
+			},
+		}
+
+		var buf testBuffer
+		w := erofs.Create(&buf)
+		if err := w.CopyFrom(src, erofs.MetadataOnly()); err != nil {
+			t.Fatal("CopyFrom:", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal("Close:", err)
+		}
+
+		erofstest.FsckErofsBytes(t, buf.Bytes())
+
+		// Open the output image and verify DataRange() on the file.
+		dstFS, err := erofs.Open(bytes.NewReader(buf.Bytes()),
+			erofs.WithExtraDevices(bytes.NewReader(make([]byte, 1024*blockSize))))
+		if err != nil {
+			t.Fatal("Open:", err)
+		}
+		info := statDataRange(t, dstFS, "data.bin")
+		if len(info) == 0 {
+			t.Fatal("DataRange() returned nil for chunk-based file")
+		}
+		// Device 0 on the source becomes DeviceID=1 in EROFS, which is
+		// what buildChunkDataRanges stores directly into DataRange.Device.
+		got := info[0]
+		if got.Device != 1 {
+			t.Errorf("Device = %d, want 1", got.Device)
+		}
+		if got.Offset != blockSize*10 {
+			t.Errorf("Offset = %d, want %d", got.Offset, blockSize*10)
+		}
+		if got.Size != blockSize*2 {
+			t.Errorf("Size = %d, want %d", got.Size, blockSize*2)
+		}
+	})
+
+	t.Run("multiple ranges on one device", func(t *testing.T) {
+		// Non-contiguous ranges: block 5 (1 block) and block 20 (3 blocks).
+		src := &dataRangerFS{
+			deviceBlocks: 1024,
+			file: &dataRangerFileInfo{
+				name: "sparse.bin",
+				size: blockSize * 4, // 4 logical blocks total
+				ranges: []erofs.DataRange{
+					{Device: 0, Offset: blockSize * 5, Size: blockSize * 1},
+					{Device: 0, Offset: blockSize * 20, Size: blockSize * 3},
+				},
+			},
+		}
+
+		var buf testBuffer
+		w := erofs.Create(&buf)
+		if err := w.CopyFrom(src, erofs.MetadataOnly()); err != nil {
+			t.Fatal("CopyFrom:", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal("Close:", err)
+		}
+
+		erofstest.FsckErofsBytes(t, buf.Bytes())
+
+		dstFS, err := erofs.Open(bytes.NewReader(buf.Bytes()),
+			erofs.WithExtraDevices(bytes.NewReader(make([]byte, 1024*blockSize))))
+		if err != nil {
+			t.Fatal("Open:", err)
+		}
+		ranges := statDataRange(t, dstFS, "sparse.bin")
+		if len(ranges) != 2 {
+			t.Fatalf("DataRange() len = %d, want 2; ranges = %v", len(ranges), ranges)
+		}
+		if ranges[0].Device != 1 || ranges[0].Offset != blockSize*5 || ranges[0].Size != blockSize {
+			t.Errorf("ranges[0] = %+v, want {Device:1 Offset:%d Size:%d}", ranges[0], blockSize*5, blockSize)
+		}
+		if ranges[1].Device != 1 || ranges[1].Offset != blockSize*20 || ranges[1].Size != blockSize*3 {
+			t.Errorf("ranges[1] = %+v, want {Device:1 Offset:%d Size:%d}", ranges[1], blockSize*20, blockSize*3)
+		}
+	})
+
+	t.Run("no data written for metadata-only", func(t *testing.T) {
+		// CopyFrom(MetadataOnly) must not copy any file data into the image.
+		// Read() returns the marker so that if CopyFrom accidentally opens
+		// and reads the file the marker will appear in the output image.
+		marker := bytes.Repeat([]byte("DATA_LEAK_CHECK"), 100)
+		src := &dataRangerFS{
+			deviceBlocks: 256,
+			file: &dataRangerFileInfo{
+				name:    "file.bin",
+				size:    int64(len(marker)),
+				content: marker,
+				ranges:  []erofs.DataRange{{Device: 0, Offset: 0, Size: int64(len(marker))}},
+			},
+		}
+		var buf testBuffer
+		w := erofs.Create(&buf)
+		if err := w.CopyFrom(src, erofs.MetadataOnly()); err != nil {
+			t.Fatal("CopyFrom:", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal("Close:", err)
+		}
+		if bytes.Contains(buf.Bytes(), marker) {
+			t.Error("metadata-only image contains file data — leak detected")
+		}
+	})
+
+	t.Run("sparse_hole_round_trip", func(t *testing.T) {
+		// A full-coverage slice with a hole entry should round-trip correctly.
+		// File layout: 1 data block at physical block 7, then 3-block hole.
+		// After CopyFrom(MetadataOnly) the output image should be valid (fsck),
+		// and reading the file back must yield:
+		//   - DataRange with Device=1, Offset=blockSize*7, Size=blockSize  (data)
+		//   - DataRange with Offset==-1, Size=blockSize*3                  (hole)
+		const blockSize = 4096
+		src := &dataRangerFS{
+			deviceBlocks: 1024,
+			file: &dataRangerFileInfo{
+				name: "sparse.bin",
+				size: blockSize * 4,
+				ranges: []erofs.DataRange{
+					{Device: 0, Offset: blockSize * 7, Size: blockSize},
+					{Offset: -1, Size: blockSize * 3},
+				},
+			},
+		}
+		var buf testBuffer
+		w := erofs.Create(&buf)
+		if err := w.CopyFrom(src, erofs.MetadataOnly()); err != nil {
+			t.Fatal("CopyFrom:", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal("Close:", err)
+		}
+
+		erofstest.FsckErofsBytes(t, buf.Bytes())
+
+		dstFS, err := erofs.Open(bytes.NewReader(buf.Bytes()),
+			erofs.WithExtraDevices(bytes.NewReader(make([]byte, 1024*blockSize))))
+		if err != nil {
+			t.Fatal("Open:", err)
+		}
+		ranges := statDataRange(t, dstFS, "sparse.bin")
+
+		// Verify total coverage equals file size.
+		var total int64
+		for _, r := range ranges {
+			total += r.Size
+		}
+		if total != blockSize*4 {
+			t.Fatalf("total DataRange size = %d, want %d; ranges = %+v", total, blockSize*4, ranges)
+		}
+
+		// Find the data range and verify it points to physical block 7 on device 1.
+		var dataRanges, holeRanges []erofs.DataRange
+		for _, r := range ranges {
+			if r.Offset == -1 {
+				holeRanges = append(holeRanges, r)
+			} else {
+				dataRanges = append(dataRanges, r)
+			}
+		}
+		if len(dataRanges) != 1 {
+			t.Fatalf("want 1 data range, got %d; ranges = %+v", len(dataRanges), ranges)
+		}
+		dr := dataRanges[0]
+		if dr.Device != 1 || dr.Offset != blockSize*7 || dr.Size != blockSize {
+			t.Errorf("data range = %+v, want {Device:1 Offset:%d Size:%d}", dr, blockSize*7, blockSize)
+		}
+		// Hole ranges should cover the remaining 3 blocks.
+		var holeTotal int64
+		for _, r := range holeRanges {
+			holeTotal += r.Size
+		}
+		if holeTotal != blockSize*3 {
+			t.Errorf("hole total = %d, want %d; holeRanges = %+v", holeTotal, blockSize*3, holeRanges)
+		}
+	})
+}
+
+// TestChunksFromRangesValidation verifies that chunksFromRanges rejects
+// invalid DataRange inputs instead of silently producing corrupt chunk entries.
+func TestChunksFromRangesValidation(t *testing.T) {
+	// Use a non-EROFS source that exercises the chunksFromRanges code path.
+	// CopyFrom(MetadataOnly) on a DataRange-implementing source calls it.
+	tryRanges := func(t *testing.T, ranges []erofs.DataRange) error {
+		t.Helper()
+		src := &dataRangerFS{
+			deviceBlocks: 1024,
+			file: &dataRangerFileInfo{
+				name:   "f.bin",
+				size:   4096 * 4,
+				ranges: ranges,
+			},
+		}
+		var buf testBuffer
+		w := erofs.Create(&buf)
+		err := w.CopyFrom(src, erofs.MetadataOnly())
+		if err == nil {
+			_ = w.Close()
+		}
+		return err
+	}
+
+	t.Run("negative offset", func(t *testing.T) {
+		err := tryRanges(t, []erofs.DataRange{{Device: 0, Offset: -4096, Size: 4096}})
+		if err == nil {
+			t.Fatal("expected error for negative Offset, got nil")
+		}
+	})
+
+	t.Run("zero size", func(t *testing.T) {
+		err := tryRanges(t, []erofs.DataRange{{Device: 0, Offset: 0, Size: 0}})
+		if err == nil {
+			t.Fatal("expected error for zero Size, got nil")
+		}
+	})
+
+	t.Run("negative size", func(t *testing.T) {
+		err := tryRanges(t, []erofs.DataRange{{Device: 0, Offset: 0, Size: -1}})
+		if err == nil {
+			t.Fatal("expected error for negative Size, got nil")
+		}
+	})
+
+	t.Run("unaligned offset", func(t *testing.T) {
+		err := tryRanges(t, []erofs.DataRange{{Device: 0, Offset: 100, Size: 4096}})
+		if err == nil {
+			t.Fatal("expected error for unaligned Offset, got nil")
+		}
+	})
+
+	t.Run("device out of range", func(t *testing.T) {
+		err := tryRanges(t, []erofs.DataRange{{Device: 1, Offset: 4096, Size: 4096}})
+		if err == nil {
+			t.Fatal("expected error for Device!=0, got nil")
+		}
+	})
+
+	t.Run("device wrap overflow", func(t *testing.T) {
+		err := tryRanges(t, []erofs.DataRange{{Device: 0xFFFF, Offset: 4096, Size: 4096}})
+		if err == nil {
+			t.Fatal("expected error for Device=0xFFFF (wraps to DeviceID=0), got nil")
+		}
+	})
+
+	t.Run("total_size_mismatch_under", func(t *testing.T) {
+		// Slice total (4096) < file size (16384).
+		err := tryRanges(t, []erofs.DataRange{{Device: 0, Offset: 0, Size: 4096}})
+		if err == nil {
+			t.Fatal("expected error for under-coverage, got nil")
+		}
+	})
+
+	t.Run("total_size_mismatch_over", func(t *testing.T) {
+		// Slice total (4096*5) > file size (16384).
+		err := tryRanges(t, []erofs.DataRange{{Device: 0, Offset: 0, Size: 4096 * 5}})
+		if err == nil {
+			t.Fatal("expected error for over-coverage, got nil")
+		}
+	})
+
+	t.Run("hole_entry_accepted", func(t *testing.T) {
+		// Full-coverage slice with a hole entry — holes are now supported.
+		// 1 data block + 3-block hole = 4 blocks == file size (16384).
+		err := tryRanges(t, []erofs.DataRange{
+			{Device: 0, Offset: 0, Size: 4096},
+			{Offset: -1, Size: 4096 * 3},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error for valid hole entry: %v", err)
+		}
+	})
+
+	t.Run("non_final_size_unaligned", func(t *testing.T) {
+		// Middle range has non-block-aligned Size (100 bytes).
+		// total = 100 + (16384-100) = 16384 so coverage is satisfied.
+		err := tryRanges(t, []erofs.DataRange{
+			{Device: 0, Offset: 0, Size: 100},
+			{Device: 0, Offset: 4096, Size: 4096*4 - 100},
+		})
+		if err == nil {
+			t.Fatal("expected error for non-final unaligned Size, got nil")
+		}
+	})
+
+	t.Run("final_size_partial_ok", func(t *testing.T) {
+		// Final range has a partial last block (file size is 16384 = 4*4096 exactly,
+		// but here we use a 3.5-block file to get a partial tail).
+		// Override file size via a separate dataRangerFS with size 4096*3+512.
+		partialSize := int64(4096*3 + 512)
+		src := &dataRangerFS{
+			deviceBlocks: 1024,
+			file: &dataRangerFileInfo{
+				name: "f.bin",
+				size: partialSize,
+				ranges: []erofs.DataRange{
+					{Device: 0, Offset: 0, Size: 4096 * 3},
+					{Device: 0, Offset: 4096 * 3, Size: 512},
+				},
+			},
+		}
+		var buf testBuffer
+		w := erofs.Create(&buf)
+		err := w.CopyFrom(src, erofs.MetadataOnly())
+		if err == nil {
+			_ = w.Close()
+		}
+		if err != nil {
+			t.Fatalf("unexpected error for valid partial final range: %v", err)
+		}
+	})
+
+	t.Run("valid range passes", func(t *testing.T) {
+		err := tryRanges(t, []erofs.DataRange{{Device: 0, Offset: 4096, Size: 4096 * 4}})
+		if err != nil {
+			t.Fatalf("unexpected error for valid range: %v", err)
+		}
+	})
+}
+
+// statDataRange opens the named file in fsys via Stat() and returns its
+// DataRange() if the FileInfo supports it.
+func statDataRange(t *testing.T, fsys fs.FS, name string) []erofs.DataRange {
+	t.Helper()
+	f, err := fsys.Open(name)
+	if err != nil {
+		t.Fatalf("Open(%s): %v", name, err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Stat(%s): %v", name, err)
+	}
+	type dataRanger interface {
+		DataRange() []erofs.DataRange
+	}
+	dr, ok := info.(dataRanger)
+	if !ok {
+		t.Fatalf("FileInfo for %s does not implement DataRange()", name)
+	}
+	return dr.DataRange()
+}

--- a/writer.go
+++ b/writer.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/erofs/go-erofs/internal/builder"
 	"github.com/erofs/go-erofs/internal/disk"
 )
 
@@ -476,6 +477,8 @@ func (w *erofsWriter) writeChunkIndexes(buf io.Writer, e *erofsEntry) error {
 	if len(e.chunks) > 0 {
 		// Walk source chunks and emit one index per logical chunk.
 		// Source chunks use block-granularity counts; we step by blocksPerChunk.
+		// A chunk with PhysicalBlock == builder.NullPhysicalBlock is a hole:
+		// emit nullIdx entries for its block span.
 		var scratch [disk.SizeChunkIndex]byte
 		ci := 0   // index into source chunks
 		coff := 0 // block offset within current source chunk
@@ -487,12 +490,19 @@ func (w *erofsWriter) writeChunkIndexes(buf io.Writer, e *erofsEntry) error {
 				continue
 			}
 			c := e.chunks[ci]
-			phys := c.PhysicalBlock + uint64(coff)
-			binary.LittleEndian.PutUint16(scratch[0:2], uint16(phys>>32))
-			binary.LittleEndian.PutUint16(scratch[2:4], c.DeviceID)
-			binary.LittleEndian.PutUint32(scratch[4:8], uint32(phys))
-			if _, err := buf.Write(scratch[:]); err != nil {
-				return err
+			if c.PhysicalBlock == builder.NullPhysicalBlock {
+				// Hole chunk: emit a null index entry.
+				if _, err := buf.Write(nullIdx[:]); err != nil {
+					return err
+				}
+			} else {
+				phys := c.PhysicalBlock + uint64(coff)
+				binary.LittleEndian.PutUint16(scratch[0:2], uint16(phys>>32))
+				binary.LittleEndian.PutUint16(scratch[2:4], c.DeviceID)
+				binary.LittleEndian.PutUint32(scratch[4:8], uint32(phys))
+				if _, err := buf.Write(scratch[:]); err != nil {
+					return err
+				}
 			}
 			coff += blocksPerChunk
 			for ci < len(e.chunks) && coff >= int(e.chunks[ci].Count) {


### PR DESCRIPTION
Access to underlying data may have multiple uses, from directly acessing file data from a backing store, detecting sparse areas in a reader, and efficiently building with metadata only.

This is needed to implement metadata only mode for tar and ext4 outside of this repository without exporting internal data structures. The data range struct is simple and can easily be utilized in an interface without exposing internal structures.