### PR TITLE
Add option to writer to set block size

### DIFF
--- a/mkfs.go
+++ b/mkfs.go
@@ -78,6 +78,7 @@ func Create(out io.WriteSeeker, opts ...CreateOpt) *Writer {
 	}
 	fsys := &Writer{
 		out:          out,
+		blockSize:    o.blockSize,
 		buildTime:    o.buildTime,
 		buildTimeNs:  o.buildTimeNs,
 		hasBuildTime: o.hasBuildTime,
@@ -127,6 +128,16 @@ func Merge() CopyOpt {
 }
 
 // --- CreateOpt functions ---
+
+// WithBlockSize sets the filesystem block size. The value must be a power
+// of two between 512 and 64 KiB. When unset the default is 4096.
+// If CopyFrom is called with a source that declares a different block size,
+// CopyFrom returns an error.
+func WithBlockSize(n int) CreateOpt {
+	return func(o *createOptions) {
+		o.blockSize = n
+	}
+}
 
 // WithBuildTime sets the filesystem build timestamp.
 func WithBuildTime(sec uint64, nsec uint32) CreateOpt {
@@ -522,6 +533,11 @@ func (fsys *Writer) Close() error {
 		defer func() { _ = fsys.spool.Close() }()
 	}
 
+	if fsys.blockSize != 0 {
+		if err := fsys.setBlockSize(fsys.blockSize); err != nil {
+			return err
+		}
+	}
 	fsys.resolveBlockSize()
 
 	if fsys.dataFile != nil {
@@ -715,6 +731,7 @@ type createOptions struct {
 	buildTime    uint64
 	buildTimeNs  uint32
 	hasBuildTime bool
+	blockSize    int      // 0 = use default
 	dataFile     *os.File // external data file for metadata-only mode
 	tempDir      string   // temp directory for spool file
 }

--- a/mkfs.go
+++ b/mkfs.go
@@ -27,6 +27,7 @@ type Writer struct {
 	buildTime    uint64 // from WithBuildTime or buildTimer
 	buildTimeNs  uint32
 	hasBuildTime bool
+	wErr         error               // sticky error: once set, all subsequent ops return it
 	root         *fsEntry            // root directory
 	byPath       map[string]*fsEntry // path → entry (all types)
 
@@ -78,7 +79,6 @@ func Create(out io.WriteSeeker, opts ...CreateOpt) *Writer {
 	}
 	fsys := &Writer{
 		out:          out,
-		blockSize:    o.blockSize,
 		buildTime:    o.buildTime,
 		buildTimeNs:  o.buildTimeNs,
 		hasBuildTime: o.hasBuildTime,
@@ -86,6 +86,12 @@ func Create(out io.WriteSeeker, opts ...CreateOpt) *Writer {
 		byPath:       map[string]*fsEntry{"/": root},
 		dataFile:     o.dataFile,
 		tempDir:      o.tempDir,
+	}
+
+	if o.blockSize != 0 {
+		if err := fsys.setBlockSize(o.blockSize); err != nil {
+			fsys.wErr = err
+		}
 	}
 
 	if o.dataFile != nil {
@@ -131,6 +137,7 @@ func Merge() CopyOpt {
 
 // WithBlockSize sets the filesystem block size. The value must be a power
 // of two between 512 and 64 KiB. When unset the default is 4096.
+// An invalid size causes subsequent Writer operations to return an error.
 // If CopyFrom is called with a source that declares a different block size,
 // CopyFrom returns an error.
 func WithBlockSize(n int) CreateOpt {
@@ -170,6 +177,9 @@ func WithTempDir(dir string) CreateOpt {
 // Create creates a regular file with default mode 0644. The caller must
 // Close the returned File.
 func (fsys *Writer) Create(name string) (*File, error) {
+	if fsys.wErr != nil {
+		return nil, fsys.wErr
+	}
 	name = cleanPath(name)
 	if name == "/" {
 		return nil, fmt.Errorf("mkfs: cannot create file at root")
@@ -209,6 +219,9 @@ func (fsys *Writer) Create(name string) (*File, error) {
 // Mkdir creates a directory. Only permission bits from perm are used;
 // type bits are forced to directory. Mkdir("/", perm) sets root permissions.
 func (fsys *Writer) Mkdir(name string, perm fs.FileMode) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	name = cleanPath(name)
 	if name == "/" {
 		fsys.root.mode = disk.StatTypeDir | uint16(perm.Perm())
@@ -231,6 +244,9 @@ func (fsys *Writer) Mkdir(name string, perm fs.FileMode) error {
 
 // Symlink creates newname as a symbolic link to oldname (mode 0777).
 func (fsys *Writer) Symlink(oldname, newname string) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	newname = cleanPath(newname)
 	if newname == "/" {
 		return fmt.Errorf("mkfs: cannot create symlink at root")
@@ -254,6 +270,9 @@ func (fsys *Writer) Symlink(oldname, newname string) error {
 // Mknod creates a device, FIFO, or socket. mode must include type bits
 // (e.g. disk.StatTypeChrdev | 0o666).
 func (fsys *Writer) Mknod(name string, mode uint16, rdev uint32) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	name = cleanPath(name)
 	if name == "/" {
 		return fmt.Errorf("mkfs: cannot mknod at root")
@@ -278,6 +297,9 @@ func (fsys *Writer) Mknod(name string, mode uint16, rdev uint32) error {
 
 // Chmod sets permission bits on the named path, preserving type bits.
 func (fsys *Writer) Chmod(name string, mode fs.FileMode) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	e, err := fsys.lookup(name)
 	if err != nil {
 		return err
@@ -289,6 +311,9 @@ func (fsys *Writer) Chmod(name string, mode fs.FileMode) error {
 
 // Chown sets the owner UID and GID on the named path.
 func (fsys *Writer) Chown(name string, uid, gid int) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	e, err := fsys.lookup(name)
 	if err != nil {
 		return err
@@ -301,6 +326,9 @@ func (fsys *Writer) Chown(name string, uid, gid int) error {
 // Chtimes sets the access and modification times on the named path.
 // EROFS only stores mtime; atime is retained for read-back before Close.
 func (fsys *Writer) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	e, err := fsys.lookup(name)
 	if err != nil {
 		return err
@@ -314,6 +342,9 @@ func (fsys *Writer) Chtimes(name string, atime time.Time, mtime time.Time) error
 
 // Setxattr sets an extended attribute on the named path.
 func (fsys *Writer) Setxattr(name, attr, value string) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	e, err := fsys.lookup(name)
 	if err != nil {
 		return err
@@ -327,6 +358,9 @@ func (fsys *Writer) Setxattr(name, attr, value string) error {
 
 // SetNlink overrides the computed link count on the named path.
 func (fsys *Writer) SetNlink(name string, nlink uint32) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	e, err := fsys.lookup(name)
 	if err != nil {
 		return err
@@ -343,6 +377,9 @@ func (fsys *Writer) SetNlink(name string, nlink uint32) error {
 // Reads symlink targets via readLinker interface when Entry.LinkTarget is empty.
 // If src implements blockSizer, the image block size is set accordingly.
 func (fsys *Writer) CopyFrom(src fs.FS, opts ...CopyOpt) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	// Reset per-CopyFrom state.
 	fsys.copyMetadataOnly = false
 	fsys.copyMerge = false
@@ -524,6 +561,9 @@ func (fsys *Writer) CopyFrom(src fs.FS, opts ...CopyOpt) error {
 
 // Close writes the EROFS image. The FS must not be used after Close.
 func (fsys *Writer) Close() error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
 	if fsys.closed {
 		return fmt.Errorf("mkfs: FS already closed")
 	}
@@ -533,11 +573,6 @@ func (fsys *Writer) Close() error {
 		defer func() { _ = fsys.spool.Close() }()
 	}
 
-	if fsys.blockSize != 0 {
-		if err := fsys.setBlockSize(fsys.blockSize); err != nil {
-			return err
-		}
-	}
 	fsys.resolveBlockSize()
 
 	if fsys.dataFile != nil {

--- a/mkfs_test.go
+++ b/mkfs_test.go
@@ -2,6 +2,7 @@ package erofs_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"io/fs"
@@ -466,6 +467,87 @@ func TestCreateFSEmpty(t *testing.T) {
 	if len(entries) != 0 {
 		t.Errorf("expected empty root dir, got %d entries", len(entries))
 	}
+}
+
+// TestCreateFSBlockSize verifies WithBlockSize produces valid images
+// with different block sizes and that invalid sizes are rejected.
+func TestCreateFSBlockSize(t *testing.T) {
+	for _, bs := range []int{512, 1024, 4096, 65536} {
+		t.Run(fmt.Sprintf("%d", bs), func(t *testing.T) {
+			var buf testBuffer
+			fsys := erofs.Create(&buf, erofs.WithBlockSize(bs))
+
+			f, err := fsys.Create("/file.txt")
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Write enough data to span multiple blocks at the smallest size.
+			data := bytes.Repeat([]byte("X"), bs+1)
+			if _, err := f.Write(data); err != nil {
+				t.Fatal(err)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := fsys.Mkdir("/dir", 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := fsys.Close(); err != nil {
+				t.Fatal("Close:", err)
+			}
+
+			// fsck.erofs mmaps the superblock and refuses block sizes
+			// larger than the host's page size, so skip it in that case.
+			// The library itself produces a valid image regardless; the
+			// remaining checks below verify it independently.
+			if bs <= os.Getpagesize() {
+				erofstest.FsckErofsBytes(t, buf.Bytes())
+			}
+
+			// Verify BlkSizeBits in the superblock.
+			var sb disk.SuperBlock
+			r := bytes.NewReader(buf.Bytes()[disk.SuperBlockOffset:])
+			if err := binary.Read(r, binary.LittleEndian, &sb); err != nil {
+				t.Fatal("decode superblock:", err)
+			}
+			if got := 1 << sb.BlkSizeBits; got != bs {
+				t.Errorf("superblock block size = %d, want %d", got, bs)
+			}
+
+			efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				t.Fatal("Open:", err)
+			}
+
+			erofstest.CheckFileBytes(t, efs, "file.txt", data)
+		})
+	}
+
+	t.Run("invalid/not-power-of-two", func(t *testing.T) {
+		var buf testBuffer
+		fsys := erofs.Create(&buf, erofs.WithBlockSize(1000))
+		if err := fsys.Close(); err == nil {
+			t.Fatal("expected error for non-power-of-two block size")
+		}
+	})
+
+	t.Run("invalid/too-small", func(t *testing.T) {
+		var buf testBuffer
+		fsys := erofs.Create(&buf, erofs.WithBlockSize(256))
+		if err := fsys.Close(); err == nil {
+			t.Fatal("expected error for block size below minimum")
+		}
+	})
+
+	t.Run("invalid/too-large", func(t *testing.T) {
+		var buf testBuffer
+		fsys := erofs.Create(&buf, erofs.WithBlockSize(2<<20))
+		if err := fsys.Close(); err == nil {
+			t.Fatal("expected error for block size above maximum")
+		}
+	})
 }
 
 // TestCreateFSSetNlink verifies that SetNlink overrides computed nlink.

--- a/mkfs_test.go
+++ b/mkfs_test.go
@@ -525,28 +525,98 @@ func TestCreateFSBlockSize(t *testing.T) {
 		})
 	}
 
-	t.Run("invalid/not-power-of-two", func(t *testing.T) {
-		var buf testBuffer
-		fsys := erofs.Create(&buf, erofs.WithBlockSize(1000))
-		if err := fsys.Close(); err == nil {
-			t.Fatal("expected error for non-power-of-two block size")
-		}
-	})
+	// Invalid sizes must surface from the first Writer operation, not be
+	// deferred until Close — otherwise a data file in WithDataFile mode
+	// could be partially written before the error fires.
+	for _, c := range []struct {
+		name string
+		size int
+	}{
+		{"not-power-of-two", 1000},
+		{"too-small", 256},
+		{"too-large", 1 << 17},
+	} {
+		t.Run("invalid/"+c.name, func(t *testing.T) {
+			var buf testBuffer
+			fsys := erofs.Create(&buf, erofs.WithBlockSize(c.size))
+			if _, err := fsys.Create("/file.txt"); err == nil {
+				t.Errorf("Create: expected error for invalid block size %d", c.size)
+			}
+			if err := fsys.Mkdir("/dir", 0o755); err == nil {
+				t.Errorf("Mkdir: expected error for invalid block size %d", c.size)
+			}
+			if err := fsys.Close(); err == nil {
+				t.Errorf("Close: expected error for invalid block size %d", c.size)
+			}
+		})
+	}
 
-	t.Run("invalid/too-small", func(t *testing.T) {
-		var buf testBuffer
-		fsys := erofs.Create(&buf, erofs.WithBlockSize(256))
-		if err := fsys.Close(); err == nil {
-			t.Fatal("expected error for block size below minimum")
+	// Data-file mode exercises the padding/chunk-index paths in
+	// File.closeDataFile, which use resolveBlockSize and so are sensitive
+	// to a non-default block size.
+	t.Run("dataFile/1024", func(t *testing.T) {
+		const bs = 1024
+		dataPath := filepath.Join(t.TempDir(), "data.bin")
+		df, err := os.Create(dataPath)
+		if err != nil {
+			t.Fatal(err)
 		}
-	})
+		defer func() { _ = df.Close() }()
 
-	t.Run("invalid/too-large", func(t *testing.T) {
-		var buf testBuffer
-		fsys := erofs.Create(&buf, erofs.WithBlockSize(2<<20))
-		if err := fsys.Close(); err == nil {
-			t.Fatal("expected error for block size above maximum")
+		var metaBuf testBuffer
+		fsys := erofs.Create(&metaBuf, erofs.WithBlockSize(bs), erofs.WithDataFile(df))
+
+		// Span multiple blocks so chunk indexes and padding both run.
+		data := bytes.Repeat([]byte("Y"), bs*3+17)
+		f, err := fsys.Create("/big.bin")
+		if err != nil {
+			t.Fatal(err)
 		}
+		if _, err := f.Write(data); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Second file, smaller than a block, to verify padding around it.
+		small := []byte("hi\n")
+		f2, err := fsys.Create("/small.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f2.Write(small); err != nil {
+			t.Fatal(err)
+		}
+		if err := f2.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := fsys.Close(); err != nil {
+			t.Fatal("Close:", err)
+		}
+
+		// Data file must be padded to a block boundary.
+		fi, err := os.Stat(dataPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Size()%int64(bs) != 0 {
+			t.Errorf("data file size %d is not a multiple of block size %d", fi.Size(), bs)
+		}
+
+		dfRead, err := os.Open(dataPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = dfRead.Close() }()
+
+		efs, err := erofs.Open(bytes.NewReader(metaBuf.Bytes()), erofs.WithExtraDevices(dfRead))
+		if err != nil {
+			t.Fatal("Open:", err)
+		}
+		erofstest.CheckFileBytes(t, efs, "big.bin", data)
+		erofstest.CheckFileBytes(t, efs, "small.txt", small)
 	})
 }
 

--- a/writer.go
+++ b/writer.go
@@ -12,8 +12,10 @@ import (
 	"github.com/erofs/go-erofs/internal/disk"
 )
 
-// maxBlockSize is the largest block size we support.
-const maxBlockSize = 1 << 20
+// maxBlockSize is the largest block size we support. EROFS images with
+// larger block sizes are unmountable on common platforms (aarch64 caps
+// page size at 64 KiB) and the reader rejects BlkSizeBits > 16.
+const maxBlockSize = 1 << 16
 
 // onlyWriter wraps an io.Writer to hide io.ReaderFrom so that
 // io.CopyBuffer uses the caller-provided buffer instead of


### PR DESCRIPTION
This is needed for generating block files other than 4096 from scratch. Useful for testing other block sizes or generating erofs with 16k block size on macOS.