### PR TITLE
Recognise ZTAILPACKING bit in FeatureIncompat

### DIFF
--- a/internal/disk/types.go
+++ b/internal/disk/types.go
@@ -4,13 +4,19 @@ const (
 	MagicNumber      = 0xe0f5e1e2
 	SuperBlockOffset = 1024
 
+	// FeatureIncompat* bits track upstream Linux's fs/erofs/erofs_fs.h.
+	// Several positions are shared by two named features.
 	FeatureIncompatLZ4_0Padding         = 0x1
 	FeatureIncompatChunkedFile          = 0x4
 	FeatureIncompatDeviceTable          = 0x8
+	FeatureIncompatComprHead2           = 0x8 // shared bit with DeviceTable
+	FeatureIncompatZTailPacking         = 0x10
 	FeatureIncompatFragments            = 0x20
+	FeatureIncompatDedupe               = 0x20 // shared bit with Fragments
 	FeatureIncompatXattrPrefixes        = 0x40
 	FeatureIncompatAll           uint32 = FeatureIncompatLZ4_0Padding |
 		FeatureIncompatChunkedFile | FeatureIncompatDeviceTable |
+		FeatureIncompatZTailPacking |
 		FeatureIncompatFragments | FeatureIncompatXattrPrefixes
 
 	SizeSuperBlock      = 128


### PR DESCRIPTION
The on-disk EROFS_FEATURE_INCOMPAT_ZTAILPACKING bit (0x10) was missing from internal/disk's FeatureIncompat constants and from the FeatureIncompatAll accept list, so any image that sets it was rejected at Open with "unsupported incompatible feature 0x10" -- even when the fields needing ztailpacking semantics weren't touched by the read path.

Modern mkfs.erofs enables ztailpacking by default for compressed inodes, so this affected real-world images. Per-inode rejection of the actual inline-pcluster behaviour already happens inside internal/zerofs.ParseHeader (h_advise's INLINE_PCLUSTER bit -> "ztailpacking not supported" with ErrNotImplemented), matching the kernel's policy of accepting known incompat bits at the superblock level and gating real usage where features are actually consumed.

Two additional aliases match upstream's shared-bit naming: ComprHead2 shares bit 0x8 with DeviceTable, and Dedupe shares bit 0x20 with Fragments. 48BIT (0x80) and METABOX (0x100) are deliberately not added: they re-shape inode/metadata encoding and silently tolerating them would lead the reader to misinterpret structures.