### PR TITLE
Add LZ4 decompression support for full lcluster layout

### DIFF
--- a/compressed_test.go
+++ b/compressed_test.go
@@ -1,0 +1,264 @@
+package erofs_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	erofs "github.com/erofs/go-erofs"
+	"github.com/erofs/go-erofs/internal/erofstest"
+)
+
+// TestCompressedLZ4 runs the standard erofstest TestCases through an
+// LZ4-compressed image (full lcluster layout, forced via -Elegacy-compress).
+// All sub-tests skip if mkfs.erofs lacks LZ4.
+func TestCompressedLZ4(t *testing.T) {
+	erofstest.RequireMkfsLZ4(t)
+
+	for _, tc := range []struct {
+		name  string
+		test  erofstest.TestCase
+		flags []string
+	}{
+		{"Basic", erofstest.Basic, nil},
+		{"FileSizes", erofstest.FileSizes, nil},
+		{"LongXattrs", erofstest.LongXattrs, erofstest.XattrPrefixFlags()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.test.Run(t, erofstest.MkfsErofsLZ4(tc.flags...))
+		})
+	}
+
+	t.Run("LargeFile", func(t *testing.T) {
+		erofstest.LargeFile.Run(t, erofstest.MkfsErofsLZ4())
+	})
+}
+
+// TestCompressedContent exercises edge cases specific to compression:
+// content compressibility, file-size boundaries, and multi-pcluster reads.
+func TestCompressedContent(t *testing.T) {
+	erofstest.RequireMkfsLZ4(t)
+
+	tc := erofstest.TarContext{}.WithModTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	t.Run("HighlyCompressible", func(t *testing.T) {
+		// 4 MiB of zeros plus 4 MiB of a repeating pattern — both very
+		// compressible.  Exercises HEAD lclusters with logically-long pclusters.
+		zeros := bytes.Repeat([]byte{0}, 4*1024*1024)
+		repeating := bytes.Repeat([]byte{'A', 'B', 'C', 'D'}, 1024*1024)
+		fsys := erofstest.MkfsErofsLZ4()(t, erofstest.TarAll(
+			tc.File("/zeros.bin", zeros, 0o644),
+			tc.File("/abcd.bin", repeating, 0o644),
+		))
+		readAndCompare(t, fsys, "zeros.bin", zeros)
+		readAndCompare(t, fsys, "abcd.bin", repeating)
+	})
+
+	t.Run("Incompressible", func(t *testing.T) {
+		// Deterministic-random bytes; mkfs.erofs should fall back to PLAIN
+		// clusters for these.
+		incompressible := make([]byte, 256*1024)
+		fillPRNG(incompressible, 0xDEADBEEF)
+		fsys := erofstest.MkfsErofsLZ4()(t, erofstest.TarAll(
+			tc.File("/random.bin", incompressible, 0o644),
+		))
+		readAndCompare(t, fsys, "random.bin", incompressible)
+	})
+
+	t.Run("BlockBoundary", func(t *testing.T) {
+		// Files at sizes near lcluster (== block size = 4 KiB) boundaries.
+		// Each file's content is verified byte-for-byte.
+		sizes := []int{1, 4095, 4096, 4097, 8191, 8192, 8193}
+		var entries []erofstest.WriterToTar
+		want := make(map[string][]byte, len(sizes))
+		for _, sz := range sizes {
+			buf := make([]byte, sz)
+			for i := range buf {
+				buf[i] = byte(i % 251)
+			}
+			name := fmt.Sprintf("/sz-%d.bin", sz)
+			entries = append(entries, tc.File(name, buf, 0o644))
+			want[name[1:]] = buf
+		}
+		fsys := erofstest.MkfsErofsLZ4()(t, erofstest.TarAll(entries...))
+		for name, expected := range want {
+			readAndCompare(t, fsys, name, expected)
+		}
+	})
+
+	t.Run("MultiPclusterSpanningRead", func(t *testing.T) {
+		// Read a large compressible file in small chunks to force many
+		// per-block loadCompressedBlock calls across multiple pclusters.
+		size := 2 * 1024 * 1024
+		buf := make([]byte, size)
+		for i := range buf {
+			buf[i] = byte((i / 64) % 251)
+		}
+		fsys := erofstest.MkfsErofsLZ4()(t, erofstest.TarAll(
+			tc.File("/big.bin", buf, 0o644),
+		))
+		f, err := fsys.Open("big.bin")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = f.Close() }()
+		got := make([]byte, 0, size)
+		chunk := make([]byte, 173) // intentionally not a power of two
+		for {
+			n, err := f.Read(chunk)
+			got = append(got, chunk[:n]...)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if !bytes.Equal(got, buf) {
+			t.Fatalf("multi-pcluster small-read mismatch: len got=%d want=%d", len(got), len(buf))
+		}
+	})
+}
+
+// TestCompressedCrossValidate builds the same tar content into both an
+// uncompressed and an LZ4 image and walks both filesystems, byte-comparing
+// every regular file.
+func TestCompressedCrossValidate(t *testing.T) {
+	erofstest.RequireMkfsLZ4(t)
+
+	tc := erofstest.TarContext{}.WithModTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	entries := []erofstest.WriterToTar{
+		tc.Dir("/d", 0o755),
+		tc.File("/d/empty.bin", []byte{}, 0o644),
+		tc.File("/d/small.bin", []byte("hello world\n"), 0o644),
+		tc.File("/d/just-block.bin", bytes.Repeat([]byte{0xAB}, 4096), 0o644),
+		tc.File("/d/just-over.bin", bytes.Repeat([]byte{0xCD}, 4097), 0o644),
+		tc.File("/d/sequence.bin", generateSeq(64*1024), 0o644),
+		tc.File("/d/zeros.bin", bytes.Repeat([]byte{0}, 64*1024), 0o644),
+		tc.File("/d/repeating.bin", bytes.Repeat([]byte("the quick brown fox jumps\n"), 1024), 0o644),
+	}
+
+	plainFsys := erofstest.MkfsErofs()(t, erofstest.TarAll(entries...))
+	lz4Fsys := erofstest.MkfsErofsLZ4()(t, erofstest.TarAll(entries...))
+
+	err := fs.WalkDir(plainFsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		plainBytes, err := fs.ReadFile(plainFsys, p)
+		if err != nil {
+			t.Errorf("plain %s: read: %v", p, err)
+			return nil
+		}
+		lz4Bytes, err := fs.ReadFile(lz4Fsys, p)
+		if err != nil {
+			t.Errorf("lz4 %s: read: %v", p, err)
+			return nil
+		}
+		if !bytes.Equal(plainBytes, lz4Bytes) {
+			t.Errorf("%s: lz4 vs plain mismatch (len %d vs %d)", p, len(lz4Bytes), len(plainBytes))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCompressedDeferred verifies that compact-layout compressed images
+// (which this library does not decode) report ErrNotImplemented from
+// Open or the first read, rather than silently producing wrong data.
+func TestCompressedDeferred(t *testing.T) {
+	erofstest.RequireMkfsLZ4(t)
+
+	t.Run("CompactLayout", func(t *testing.T) {
+		// Default mkfs.erofs `-z lz4` produces the compact lcluster
+		// layout, which this library does not decode.
+		tc := erofstest.TarContext{}.WithModTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+		wt := erofstest.TarAll(
+			tc.File("/big.bin", bytes.Repeat([]byte{0xAA}, 64*1024), 0o644),
+		)
+		tarStream := erofstest.TarFromWriterTo(wt)
+		defer func() { _ = tarStream.Close() }()
+		path := filepath.Join(t.TempDir(), "compact.erofs")
+		if err := erofstest.ConvertTarErofs(context.Background(), tarStream, path, "", []string{"-z", "lz4"}); err != nil {
+			t.Fatal(err)
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = f.Close() }()
+
+		fsys, err := erofs.Open(f)
+		if err != nil {
+			// Some mkfs.erofs versions may produce full layout even without
+			// -Elegacy-compress for short files; if Open already errored,
+			// that's also acceptable as long as it's ErrNotImplemented.
+			if !errors.Is(err, erofs.ErrNotImplemented) {
+				t.Fatalf("Open: want ErrNotImplemented, got %v", err)
+			}
+			return
+		}
+		// Reading the compressed file should fail with ErrNotImplemented
+		// at loadCompressedBlock time.
+		_, err = fs.ReadFile(fsys, "big.bin")
+		if err == nil {
+			t.Fatal("expected an error reading compact-layout file, got nil")
+		}
+		if !errors.Is(err, erofs.ErrNotImplemented) {
+			t.Errorf("compact-layout read: want ErrNotImplemented, got %v", err)
+		}
+	})
+}
+
+// readAndCompare opens name, reads it fully, and compares against want.
+func readAndCompare(t testing.TB, fsys fs.FS, name string, want []byte) {
+	t.Helper()
+	got, err := fs.ReadFile(fsys, name)
+	if err != nil {
+		t.Errorf("read %s: %v", name, err)
+		return
+	}
+	if !bytes.Equal(got, want) {
+		// Find the first mismatch for a useful message.
+		for i := 0; i < len(got) && i < len(want); i++ {
+			if got[i] != want[i] {
+				t.Errorf("%s: first mismatch at offset %d (got 0x%02x, want 0x%02x); lengths got=%d want=%d",
+					name, i, got[i], want[i], len(got), len(want))
+				return
+			}
+		}
+		t.Errorf("%s: length mismatch got=%d want=%d", name, len(got), len(want))
+	}
+}
+
+func generateSeq(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(i % 251)
+	}
+	return b
+}
+
+// fillPRNG fills b with deterministic bytes via xorshift32 seeded by seed.
+func fillPRNG(b []byte, seed uint32) {
+	x := seed
+	for i := range b {
+		x ^= x << 13
+		x ^= x >> 17
+		x ^= x << 5
+		b[i] = byte(x)
+	}
+}

--- a/erofs.go
+++ b/erofs.go
@@ -40,6 +40,7 @@ import (
 	"time"
 
 	"github.com/erofs/go-erofs/internal/disk"
+	"github.com/erofs/go-erofs/internal/zerofs"
 )
 
 // Errors
@@ -184,11 +185,30 @@ func Open(r io.ReaderAt, opts ...OpenOpt) (fs.FS, error) {
 		}
 	}
 
-	// Error out filesystems with unsupported compressed inodes
-	if i.sb.FeatureIncompat&disk.FeatureIncompatLZ4_0Padding != 0 ||
-		i.sb.ComprAlgs != 0 {
-		return nil, fmt.Errorf("unsupported compressed filesystem (FeatureIncompat=0x%x, ComprAlgs=0x%x): %w",
-			i.sb.FeatureIncompat, i.sb.ComprAlgs, ErrNotImplemented)
+	// LZ4 is the only supported compression algorithm. The LZ4_0PADDING
+	// incompat bit marks the standard EROFS layout where the LZ4 stream
+	// sits at the end of each physical block with leading zero padding;
+	// the in-tree decoder in internal/zerofs scans that margin.
+	//
+	// SuperBlock.ComprAlgs is a union: when COMPR_CFGS is set it is a
+	// bitmap of available algorithms; otherwise it is lz4_max_distance,
+	// and the image uses LZ4 implicitly (no other algorithm was supported
+	// in pre-COMPR_CFGS erofs).
+	i.lz4Cfg.MaxPclusterBlks = 1
+	if i.sb.FeatureIncompat&disk.FeatureIncompatComprCfgs != 0 {
+		if i.sb.ComprAlgs&^disk.ComprAlgLZ4 != 0 {
+			return nil, fmt.Errorf("unsupported compression algorithm 0x%x (only LZ4 supported): %w",
+				i.sb.ComprAlgs, ErrNotImplemented)
+		}
+		if err := i.parseComprCfgs(); err != nil {
+			return nil, err
+		}
+	} else {
+		// Pre-COMPR_CFGS image: u1 is lz4_max_distance rather than a
+		// ComprAlgs bitmap. Recorded for reference; the in-tree LZ4
+		// decoder bounds match offsets against the current decompressed
+		// pcluster buffer regardless of this value.
+		i.lz4Cfg.MaxDistance = i.sb.ComprAlgs
 	}
 
 	i.blkPool.New = func() any {
@@ -234,6 +254,60 @@ type image struct {
 	longPrefixes []string // cached long xattr prefixes
 	prefixesOnce sync.Once
 	prefixesErr  error
+
+	// lz4Cfg holds parsed COMPR_CFGS / defaults for LZ4 decompression.
+	lz4Cfg disk.LZ4Cfgs
+
+	// pcCache caches recently decompressed pclusters across compressed reads.
+	pcCacheOnce sync.Once
+	pcCache     *pclusterCache
+}
+
+// maxLZ4PclusterBlks bounds MaxPclusterBlks parsed from COMPR_CFGS. The Linux
+// kernel enforces the same 1 MiB ceiling.
+const maxLZ4PclusterBlks = 256
+
+// parseComprCfgs walks the compression configuration records that follow the
+// superblock. Each record is [u16 size][size bytes payload]; one record per
+// bit set in sb.ComprAlgs in least-significant-bit-first order.
+func (img *image) parseComprCfgs() error {
+	pos := int64(disk.SuperBlockOffset + disk.SizeSuperBlock)
+	algs := img.sb.ComprAlgs
+	for bit := uint16(0); algs != 0; bit++ {
+		mask := uint16(1) << bit
+		if algs&mask == 0 {
+			continue
+		}
+		algs &^= mask
+		var sizeBuf [2]byte
+		if _, err := img.meta.ReadAt(sizeBuf[:], pos); err != nil {
+			return fmt.Errorf("read compr_cfgs size at %d: %w", pos, err)
+		}
+		size := int(binary.LittleEndian.Uint16(sizeBuf[:]))
+		pos += 2
+		payload := make([]byte, size)
+		if _, err := img.meta.ReadAt(payload, pos); err != nil {
+			return fmt.Errorf("read compr_cfgs payload at %d (size=%d): %w", pos, size, err)
+		}
+		pos += int64(size)
+		if mask == disk.ComprAlgLZ4 {
+			if size < disk.SizeLZ4Cfgs {
+				return fmt.Errorf("lz4 compr_cfgs payload too short: %d < %d: %w",
+					size, disk.SizeLZ4Cfgs, ErrInvalidSuperblock)
+			}
+			if _, err := binary.Decode(payload[:disk.SizeLZ4Cfgs], binary.LittleEndian, &img.lz4Cfg); err != nil {
+				return fmt.Errorf("decode lz4 compr_cfgs: %w", err)
+			}
+			if img.lz4Cfg.MaxPclusterBlks == 0 {
+				img.lz4Cfg.MaxPclusterBlks = 1
+			}
+			if img.lz4Cfg.MaxPclusterBlks > maxLZ4PclusterBlks {
+				return fmt.Errorf("max_pclusterblks %d exceeds limit %d: %w",
+					img.lz4Cfg.MaxPclusterBlks, maxLZ4PclusterBlks, ErrInvalid)
+			}
+		}
+	}
+	return nil
 }
 
 // start physical offset of the separate metadata zone
@@ -658,7 +732,7 @@ func (img *image) loadBlock(fi *inode, pos int64) (*block, error) {
 		b.end = int32(blockEnd)
 		return b, nil
 	case disk.LayoutCompressedFull, disk.LayoutCompressedCompact:
-		return nil, fmt.Errorf("inode layout (%d) for %d: %w", fi.inodeLayout, fi.nid, ErrNotImplemented)
+		return img.loadCompressedBlock(fi, pos)
 	default:
 		return nil, fmt.Errorf("inode layout (%d) for %d: %w", fi.inodeLayout, fi.nid, ErrInvalid)
 	}
@@ -677,6 +751,230 @@ func (img *image) loadBlock(fi *inode, pos int64) (*block, error) {
 		return nil, fmt.Errorf("failed to read full block for nid %d: %w, expected %d, actual %d", fi.nid, ErrInvalid, blockEnd-blockOffset, n)
 	}
 	return b, nil
+}
+
+// loadCompressedBlock returns the logical block containing file offset pos
+// for a compressed inode. It locates the containing pcluster via the inode's
+// zerofs.Decoder, fetches the decompressed pcluster bytes (LRU-cached), and
+// returns the block-slice between pos (rounded down to the block start) and
+// either the block end or the pcluster end, whichever comes first.
+//
+// The returned block's [offset, end) slice covers the bytes from pos to
+// whichever of (block end, pcluster end, file end) comes first. Reading a
+// block that straddles a pcluster boundary requires two calls (the caller
+// resumes at the pcluster boundary).
+func (img *image) loadCompressedBlock(fi *inode, pos int64) (*block, error) {
+	dec, err := img.zDecoder(fi)
+	if err != nil {
+		return nil, err
+	}
+	if pos < 0 || pos >= fi.size {
+		return nil, fmt.Errorf("compressed read out of range: pos=%d size=%d: %w", pos, fi.size, io.EOF)
+	}
+
+	pc, err := dec.FindPclusterForOffset(pos)
+	if err != nil {
+		return nil, fmt.Errorf("nid %d: %w", fi.nid, err)
+	}
+
+	pcBytes, err := img.getOrDecompressPcluster(fi.nid, dec, pc)
+	if err != nil {
+		return nil, fmt.Errorf("nid %d: %w", fi.nid, err)
+	}
+
+	blkSize := int64(1 << img.sb.BlkSizeBits)
+	blockStart := pos &^ (blkSize - 1)
+	blockEnd := blockStart + blkSize
+
+	// Clip the slice to the pcluster and to the file end.
+	sliceEnd := blockEnd
+	if sliceEnd > pc.LogStart+pc.LogLen {
+		sliceEnd = pc.LogStart + pc.LogLen
+	}
+	if sliceEnd > fi.size {
+		sliceEnd = fi.size
+	}
+	if pos >= sliceEnd {
+		// Should not happen: FindPclusterForOffset returned a pcluster that
+		// does not actually contain pos.
+		return nil, fmt.Errorf("nid %d: pos %d not in pcluster [%d,%d): %w",
+			fi.nid, pos, pc.LogStart, pc.LogStart+pc.LogLen, ErrInvalid)
+	}
+
+	startInPC := pos - pc.LogStart
+	endInPC := sliceEnd - pc.LogStart
+
+	b := img.getBlock()
+	posInBlock := int(pos - blockStart)
+	n := copy(b.buf[posInBlock:int(blkSize)], pcBytes[startInPC:endInPC])
+	b.offset = int32(posInBlock)
+	b.end = int32(posInBlock + n)
+	return b, nil
+}
+
+// zDecoder returns the inode's compressed-data decoder, building it on first
+// use. Errors during initialisation are cached so we don't retry the same
+// invalid header repeatedly.
+func (img *image) zDecoder(fi *inode) (*zerofs.Decoder, error) {
+	if fi.zdec != nil {
+		return fi.zdec, nil
+	}
+	if fi.zdecErr != nil {
+		return nil, fi.zdecErr
+	}
+	dec, err := img.buildZDecoder(fi)
+	if err != nil {
+		fi.zdecErr = err
+		return nil, err
+	}
+	fi.zdec = dec
+	return dec, nil
+}
+
+func (img *image) buildZDecoder(fi *inode) (*zerofs.Decoder, error) {
+	inodeAddr := img.metaStartPos() + int64(fi.nid)*disk.SizeInodeCompact
+	mapHeaderAddr := alignUp8(inodeAddr + int64(fi.icsize) + int64(fi.xsize))
+
+	var hbuf [disk.SizeZMapHeader]byte
+	if err := img.readMapHeader(fi, mapHeaderAddr, hbuf[:]); err != nil {
+		return nil, err
+	}
+	header, err := zerofs.ParseHeader(hbuf[:])
+	if err != nil {
+		return nil, err
+	}
+
+	lclusterBits := img.sb.BlkSizeBits + (header.ClusterBits & 7)
+	if lclusterBits < img.sb.BlkSizeBits {
+		return nil, fmt.Errorf("nid %d: invalid lclusterbits %d (blkSizeBits=%d)",
+			fi.nid, lclusterBits, img.sb.BlkSizeBits)
+	}
+	lcsize := int64(1) << lclusterBits
+	nlc := int((fi.size + lcsize - 1) / lcsize)
+
+	if fi.inodeLayout != disk.LayoutCompressedFull {
+		return nil, fmt.Errorf("nid %d: compact lcluster layout not yet supported: %w",
+			fi.nid, ErrNotImplemented)
+	}
+
+	// The lcluster index follows the 8-byte map header. mkfs.erofs's legacy
+	// (pre-COMPR_CFGS) full layout inserts an additional 8 bytes of padding
+	// between the header and the index; modern images do not. We detect
+	// legacy mode by the absence of FeatureIncompatComprCfgs.
+	indexBase := mapHeaderAddr + disk.SizeZMapHeader
+	if img.sb.FeatureIncompat&disk.FeatureIncompatComprCfgs == 0 {
+		indexBase += 8 // Z_EROFS_LEGACY_HEADER_PADDING
+	}
+
+	return &zerofs.Decoder{
+		Meta:         img.meta,
+		IndexBase:    indexBase,
+		Layout:       fi.inodeLayout,
+		BlkSizeBits:  img.sb.BlkSizeBits,
+		LclusterBits: lclusterBits,
+		Header:       header,
+		Size:         fi.size,
+		NLclusters:   nlc,
+	}, nil
+}
+
+// readMapHeader fills dst with the 8 bytes at addr. It prefers the cached
+// inode block when the header sits within it; otherwise it reads through the
+// meta ReaderAt.
+func (img *image) readMapHeader(fi *inode, addr int64, dst []byte) error {
+	if fi.cached != nil {
+		blkSize := int64(1 << img.sb.BlkSizeBits)
+		blockStart := (img.metaStartPos() + int64(fi.nid)*disk.SizeInodeCompact) &^ (blkSize - 1)
+		off := addr - blockStart
+		if off >= 0 && off+int64(len(dst)) <= int64(len(fi.cached.buf)) &&
+			off+int64(len(dst)) <= int64(fi.cached.end) {
+			copy(dst, fi.cached.buf[off:off+int64(len(dst))])
+			return nil
+		}
+	}
+	if _, err := img.meta.ReadAt(dst, addr); err != nil {
+		return fmt.Errorf("read map header at %d: %w", addr, err)
+	}
+	return nil
+}
+
+func alignUp8(v int64) int64 { return (v + 7) &^ 7 }
+
+// pclusterCacheSize bounds the LRU. With MaxPclusterBlks=1 (default), each
+// entry holds at most one block's decompressed bytes (~lclusterSize each);
+// total worst case ~cap * MaxPclusterBlks * blockSize.
+const pclusterCacheSize = 8
+
+type pclusterKey struct {
+	nid     uint64
+	headBlk uint32
+}
+
+type pclusterCacheEntry struct {
+	key  pclusterKey
+	data []byte
+}
+
+type pclusterCache struct {
+	mu    sync.Mutex
+	cap   int
+	items map[pclusterKey]int // key -> index in order
+	order []*pclusterCacheEntry
+}
+
+func newPclusterCache(cap int) *pclusterCache {
+	return &pclusterCache{cap: cap, items: make(map[pclusterKey]int, cap)}
+}
+
+func (c *pclusterCache) get(k pclusterKey) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	idx, ok := c.items[k]
+	if !ok {
+		return nil, false
+	}
+	e := c.order[idx]
+	// Move to MRU (end of slice).
+	if idx != len(c.order)-1 {
+		copy(c.order[idx:], c.order[idx+1:])
+		c.order[len(c.order)-1] = e
+		for i := idx; i < len(c.order); i++ {
+			c.items[c.order[i].key] = i
+		}
+	}
+	return e.data, true
+}
+
+func (c *pclusterCache) put(k pclusterKey, data []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.items[k]; ok {
+		return
+	}
+	if len(c.order) >= c.cap {
+		evict := c.order[0]
+		c.order = c.order[1:]
+		delete(c.items, evict.key)
+		for i, e := range c.order {
+			c.items[e.key] = i
+		}
+	}
+	c.order = append(c.order, &pclusterCacheEntry{key: k, data: data})
+	c.items[k] = len(c.order) - 1
+}
+
+func (img *image) getOrDecompressPcluster(nid uint64, dec *zerofs.Decoder, pc zerofs.Pcluster) ([]byte, error) {
+	img.pcCacheOnce.Do(func() { img.pcCache = newPclusterCache(pclusterCacheSize) })
+	key := pclusterKey{nid: nid, headBlk: pc.HeadBlk}
+	if data, ok := img.pcCache.get(key); ok {
+		return data, nil
+	}
+	buf := make([]byte, pc.LogLen)
+	if _, err := zerofs.Decompress(img.meta, img.sb.BlkSizeBits, pc, buf); err != nil {
+		return nil, err
+	}
+	img.pcCache.put(key, buf)
+	return buf, nil
 }
 
 func (img *image) getBlock() *block {
@@ -1441,6 +1739,11 @@ type inode struct {
 	mtime       uint64
 	mtimeNs     uint32
 	cached      *block
+
+	// zdec is the lazily-initialised compressed-data decoder. Only set for
+	// inodes whose inodeLayout is LayoutCompressedFull or LayoutCompressedCompact.
+	zdec    *zerofs.Decoder
+	zdecErr error
 }
 
 func (ino *inode) flatDataOffset() int64 {

--- a/erofs_fuzz_test.go
+++ b/erofs_fuzz_test.go
@@ -941,3 +941,55 @@ func FuzzImageCorruptInode(f *testing.F) {
 		exerciseFS(fsys)
 	})
 }
+
+// buildMinimalCompressedImage creates a small valid LZ4-compressed erofs
+// image (full lcluster layout) for use as a fuzz seed.
+func buildMinimalCompressedImage(t testing.TB) []byte {
+	t.Helper()
+	erofstest.RequireMkfsLZ4(t)
+
+	tc := erofstest.TarContext{}.WithModTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	wt := erofstest.TarAll(
+		tc.Dir("/dir", 0755),
+		// Repeating content so the file is actually compressed (mkfs.erofs
+		// otherwise falls back to PLAIN).
+		tc.File("/dir/repeat.bin", bytes.Repeat([]byte{0xAB, 0xCD}, 8192), 0644),
+		tc.File("/dir/zeros.bin", bytes.Repeat([]byte{0}, 16384), 0644),
+		tc.File("/empty", []byte{}, 0644),
+	)
+	tarStream := erofstest.TarFromWriterTo(wt)
+	defer func() { _ = tarStream.Close() }()
+
+	path := filepath.Join(t.TempDir(), "minimal-compressed.erofs")
+	if err := erofstest.ConvertTarErofs(context.Background(), tarStream, path, "",
+		[]string{"-zlz4", "-Elegacy-compress"}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+// FuzzImageOpenCompressed fuzzes the raw bytes of a compressed (LZ4)
+// erofs image. Open + exerciseFS must never panic, regardless of how the
+// compressed metadata or pcluster data is mangled.
+func FuzzImageOpenCompressed(f *testing.F) {
+	seed := buildMinimalCompressedImage(f)
+	f.Add(seed)
+
+	// A truncated seed exposes early-EOF handling in the compressed path.
+	if len(seed) > 2048 {
+		f.Add(seed[:2048])
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		r := bytes.NewReader(data)
+		fsys, err := erofs.Open(r)
+		if err != nil {
+			return
+		}
+		exerciseFS(fsys)
+	})
+}

--- a/erofs_test.go
+++ b/erofs_test.go
@@ -1,6 +1,7 @@
 package erofs_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -61,14 +62,16 @@ func TestErofs(t *testing.T) {
 		erofstest.SparseFiles.Run(t, erofstest.MkfsErofsMaxSize(1024*1024, chunkFlag))
 	})
 
-	// Compression format is unimplemented — verify EroFS returns ErrNotImplemented.
-	t.Run("lz4-unimplemented", func(t *testing.T) {
+	// LZ4-compressed image with the legacy (full) lcluster layout: open
+	// and read a small file end-to-end.
+	t.Run("lz4-full-layout", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("mkfs.erofs compression is not included on Windows")
 		}
 		tc := erofstest.TarContext{}
+		content := []byte("content\n")
 		wt := erofstest.TarAll(
-			tc.File("/file.txt", []byte("content\n"), 0644),
+			tc.File("/file.txt", content, 0644),
 		)
 		tarStream := erofstest.TarFromWriterTo(wt)
 		defer func() {
@@ -78,7 +81,10 @@ func TestErofs(t *testing.T) {
 		}()
 
 		path := filepath.Join(t.TempDir(), "compressed.erofs")
-		if err := erofstest.ConvertTarErofs(context.Background(), tarStream, path, "", []string{"-zlz4"}); err != nil {
+		// -Elegacy-compress forces the full lcluster layout; the compact
+		// alternative is not decoded by this library.
+		if err := erofstest.ConvertTarErofs(context.Background(), tarStream, path, "",
+			[]string{"-zlz4", "-Elegacy-compress"}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -92,9 +98,16 @@ func TestErofs(t *testing.T) {
 			}
 		}()
 
-		_, err = erofs.Open(f)
-		if !errors.Is(err, erofs.ErrNotImplemented) {
-			t.Fatalf("expected ErrNotImplemented, got %v", err)
+		fsys, err := erofs.Open(f)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		got, err := fs.ReadFile(fsys, "file.txt")
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		if !bytes.Equal(got, content) {
+			t.Fatalf("file.txt content: got %q want %q", got, content)
 		}
 	})
 }

--- a/internal/disk/types.go
+++ b/internal/disk/types.go
@@ -4,12 +4,17 @@ const (
 	MagicNumber      = 0xe0f5e1e2
 	SuperBlockOffset = 1024
 
-	FeatureIncompatLZ4_0Padding         = 0x1
+	FeatureIncompatLZ4_0Padding = 0x1
+	// FeatureIncompatComprCfgs (also Z_EROFS_FEATURE_INCOMPAT_BIG_PCLUSTER, same
+	// bit) marks the presence of compression configuration descriptors after the
+	// superblock.
+	FeatureIncompatComprCfgs            = 0x2
 	FeatureIncompatChunkedFile          = 0x4
 	FeatureIncompatDeviceTable          = 0x8
 	FeatureIncompatFragments            = 0x20
 	FeatureIncompatXattrPrefixes        = 0x40
 	FeatureIncompatAll           uint32 = FeatureIncompatLZ4_0Padding |
+		FeatureIncompatComprCfgs |
 		FeatureIncompatChunkedFile | FeatureIncompatDeviceTable |
 		FeatureIncompatFragments | FeatureIncompatXattrPrefixes
 
@@ -21,6 +26,9 @@ const (
 	SizeXattrEntry      = 4
 	SizeDeviceSlot      = 128
 	SizeChunkIndex      = 8
+	SizeZMapHeader      = 8
+	SizeLclusterIndex   = 8
+	SizeLZ4Cfgs         = 14
 
 	LayoutFlatPlain         = 0
 	LayoutCompressedFull    = 1
@@ -31,6 +39,38 @@ const (
 	LayoutChunkFormatBits    = 0x001F
 	LayoutChunkFormatIndexes = 0x0020
 	LayoutChunkFormat48Bit   = 0x0040
+
+	// ComprAlg* are bits in SuperBlock.ComprAlgs identifying which compression
+	// algorithms appear in the image.
+	ComprAlgLZ4     = 0x1
+	ComprAlgLZMA    = 0x2
+	ComprAlgDeflate = 0x4
+	ComprAlgZstd    = 0x8
+
+	// ZLclusterType* are the values of the lower 2 bits of
+	// z_erofs_lcluster_index.di_advise.
+	ZLclusterTypePlain   = 0
+	ZLclusterTypeHead1   = 1
+	ZLclusterTypeNonhead = 2
+	ZLclusterTypeHead2   = 3
+	ZLclusterTypeMask    = 0x3
+
+	// ZLclusterPartialRef indicates the lcluster's data may be shared with
+	// another inode (dedupe). Unused for read; kept here for completeness.
+	ZLclusterPartialRef = 1 << 2
+
+	// ZLclusterD0CBlkCnt: when set in a full-layout NONHEAD's delta[0]
+	// (low 16 bits of di_u), the remaining 11 bits encode the physical block
+	// count of the surrounding pcluster (big pcluster).
+	ZLclusterD0CBlkCnt = 1 << 11
+
+	// ZAdvise* are bits in z_erofs_map_header.h_advise.
+	ZAdviseCompacted2B        = 1 << 0
+	ZAdviseBigPcluster1       = 1 << 1
+	ZAdviseBigPcluster2       = 1 << 2
+	ZAdviseInlinePcluster     = 1 << 3
+	ZAdviseInterlacedPcluster = 1 << 4
+	ZAdviseFragmentPcluster   = 1 << 5
 )
 
 // SuperBlock represents the EROFS on-disk superblock.
@@ -143,6 +183,37 @@ type InodeChunkIndex struct {
 	StartBlkHi uint16 // part of 48-bit support (not yet implemented)
 	DeviceID   uint16
 	StartBlkLo uint32
+}
+
+// ZMapHeader is the 8-byte z_erofs_map_header that sits after xattrs in a
+// compressed inode and describes the cluster index layout that follows.
+type ZMapHeader struct {
+	Reserved1     uint16
+	IdataSize     uint16
+	Advise        uint16
+	ClusterBits   uint8 // log2(lcluster size) - SuperBlock.BlkSizeBits (low 3 bits)
+	AlgorithmType uint8 // low 4 bits: head1 algo; high 4 bits: head2 algo
+}
+
+// LclusterIndex is an 8-byte z_erofs_lcluster_index entry in the
+// LayoutCompressedFull index map.
+//
+// For PLAIN/HEAD types, U is the physical block address of the (start of the)
+// pcluster.  For NONHEAD types, the low 16 bits of U are delta[0] (distance
+// back to the head lcluster) and the high 16 bits are delta[1] (distance
+// forward to the next head).
+type LclusterIndex struct {
+	Advise     uint16
+	ClusterOfs uint16
+	U          uint32
+}
+
+// LZ4Cfgs is the LZ4 entry of the COMPR_CFGS records that follow the
+// superblock when FeatureIncompatComprCfgs is set.
+type LZ4Cfgs struct {
+	MaxDistance     uint16
+	MaxPclusterBlks uint16
+	Reserved        [10]uint8
 }
 
 // DeviceSlot represents the on-disk device table entry (erofs_deviceslot).

--- a/internal/erofstest/compressed.go
+++ b/internal/erofstest/compressed.go
@@ -1,0 +1,54 @@
+package erofstest
+
+import (
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// MkfsErofsLZ4 returns a Converter that runs mkfs.erofs with `-z lz4` plus
+// `-Elegacy-compress` to force the full (legacy) lcluster layout. Pass any
+// additional mkfs.erofs flags via extraOpts.
+//
+// Tests that use this should also call [RequireMkfsLZ4] first to t.Skip when
+// the local mkfs.erofs lacks LZ4 support.
+func MkfsErofsLZ4(extraOpts ...string) Converter {
+	return MkfsErofs(append([]string{"-z", "lz4", "-Elegacy-compress"}, extraOpts...)...)
+}
+
+
+var (
+	mkfsLZ4Once   sync.Once
+	mkfsLZ4Avail  bool
+	mkfsLZ4Reason string
+)
+
+// RequireMkfsLZ4 skips t when mkfs.erofs is not on PATH or does not support
+// LZ4 compression.
+func RequireMkfsLZ4(t testing.TB) {
+	t.Helper()
+	mkfsLZ4Once.Do(checkMkfsLZ4)
+	if !mkfsLZ4Avail {
+		t.Skipf("mkfs.erofs lz4 unavailable: %s", mkfsLZ4Reason)
+	}
+}
+
+func checkMkfsLZ4() {
+	if _, err := exec.LookPath("mkfs.erofs"); err != nil {
+		mkfsLZ4Reason = "mkfs.erofs not on PATH"
+		return
+	}
+	// Attempt a tiny LZ4 conversion. mkfs.erofs reads tar input from stdin
+	// with --tar=f. We pipe an empty tar (a 1024-byte zero tail) and check
+	// only the early reject path: if LZ4 is unsupported, mkfs.erofs prints
+	// "Unsupported compression algorithm" or similar before consuming input.
+	cmd := exec.Command("mkfs.erofs", "--help")
+	out, _ := cmd.CombinedOutput()
+	help := strings.ToLower(string(out))
+	if !strings.Contains(help, "lz4") {
+		mkfsLZ4Reason = "mkfs.erofs --help does not advertise lz4"
+		return
+	}
+	mkfsLZ4Avail = true
+}

--- a/internal/zerofs/decompress.go
+++ b/internal/zerofs/decompress.go
@@ -1,0 +1,76 @@
+package zerofs
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/erofs/go-erofs/internal/disk"
+)
+
+// Decompress reads the pcluster's compressed bytes via meta (which is the
+// io.ReaderAt providing the same physical address space the lcluster
+// BlkAddr values point into) and writes its decompressed output into out.
+//
+// out must be at least p.LogLen bytes long. The function returns the number
+// of decompressed bytes written; for well-formed images this always equals
+// p.LogLen.
+func Decompress(meta io.ReaderAt, blkSizeBits uint8, p Pcluster, out []byte) (int, error) {
+	blkSize := int(1) << blkSizeBits
+	if int64(len(out)) < p.LogLen {
+		return 0, fmt.Errorf("decompress output buffer too small: %d < %d", len(out), p.LogLen)
+	}
+	physOff := int64(p.HeadBlk) << blkSizeBits
+
+	switch p.HeadType {
+	case disk.ZLclusterTypePlain:
+		n, err := readFull(meta, out[:p.LogLen], physOff)
+		if err != nil {
+			return 0, fmt.Errorf("plain pcluster head=%d read: %w", p.HeadLcn, err)
+		}
+		return n, nil
+	case disk.ZLclusterTypeHead1:
+		src := make([]byte, int(p.NPhysBlks)*blkSize)
+		if _, err := readFull(meta, src, physOff); err != nil {
+			return 0, fmt.Errorf("lz4 pcluster head=%d compressed read: %w", p.HeadLcn, err)
+		}
+		// EROFS LZ4_0Padding mode places the LZ4 stream at the END of the
+		// physical block(s) and pads leading bytes with zeros. Skip the
+		// leading zero margin to find the actual LZ4 stream start, matching
+		// the kernel's inputmargin scan in z_erofs_lz4_decompress_mem.
+		inputMargin := 0
+		for inputMargin < len(src) && src[inputMargin] == 0 {
+			inputMargin++
+		}
+		if inputMargin >= len(src) {
+			return 0, fmt.Errorf("lz4 pcluster head=%d: physical block is all zeros: %w",
+				p.HeadLcn, ErrCorrupt)
+		}
+		n, err := uncompressLZ4Partial(out[:p.LogLen], src[inputMargin:])
+		if err != nil {
+			return 0, fmt.Errorf("lz4 decompress head=%d (src=%d margin=%d, dst=%d): %w",
+				p.HeadLcn, len(src), inputMargin, p.LogLen, err)
+		}
+		if int64(n) != p.LogLen {
+			return 0, fmt.Errorf("lz4 decompress head=%d: got %d bytes, want %d: %w",
+				p.HeadLcn, n, p.LogLen, ErrCorrupt)
+		}
+		return n, nil
+	default:
+		return 0, fmt.Errorf("unsupported head type %d: %w", p.HeadType, ErrNotImplemented)
+	}
+}
+
+func readFull(r io.ReaderAt, dst []byte, off int64) (int, error) {
+	total := 0
+	for total < len(dst) {
+		n, err := r.ReadAt(dst[total:], off+int64(total))
+		total += n
+		if err != nil {
+			if total == len(dst) {
+				return total, nil
+			}
+			return total, err
+		}
+	}
+	return total, nil
+}

--- a/internal/zerofs/header.go
+++ b/internal/zerofs/header.go
@@ -1,0 +1,63 @@
+// Package zerofs implements the z_erofs (compressed EROFS) read path:
+// parsing the per-inode map header, decoding the LayoutCompressedFull
+// lcluster index, and decompressing physical clusters with LZ4.
+//
+// Features outside this set -- LayoutCompressedCompact, ztailpacking,
+// fragments, interlaced pclusters, head2, and non-LZ4 algorithms --
+// return ErrNotImplemented from ParseHeader or the Decoder so the
+// caller can surface the limitation to the user rather than silently
+// returning wrong data.
+package zerofs
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/erofs/go-erofs/internal/disk"
+)
+
+// ErrNotImplemented is returned when a parsable but unsupported feature is
+// encountered. It is wrapped by the package's error messages and re-exported
+// by callers as erofs.ErrNotImplemented (matching by errors.Is).
+var ErrNotImplemented = errors.New("not implemented")
+
+// ErrCorrupt is returned for inconsistencies in the compressed metadata —
+// values that should never appear in a well-formed image.
+var ErrCorrupt = errors.New("corrupt compressed metadata")
+
+// ParseHeader decodes the 8-byte z_erofs_map_header and rejects features
+// that this package does not implement.
+func ParseHeader(buf []byte) (disk.ZMapHeader, error) {
+	var h disk.ZMapHeader
+	if len(buf) < disk.SizeZMapHeader {
+		return h, fmt.Errorf("z_erofs_map_header: short buffer (%d bytes)", len(buf))
+	}
+	if _, err := binary.Decode(buf[:disk.SizeZMapHeader], binary.LittleEndian, &h); err != nil {
+		return h, fmt.Errorf("z_erofs_map_header: %w", err)
+	}
+	if h.IdataSize != 0 {
+		return h, fmt.Errorf("inline pcluster data (idata_size=%d): %w", h.IdataSize, ErrNotImplemented)
+	}
+	if h.Advise&disk.ZAdviseInlinePcluster != 0 {
+		return h, fmt.Errorf("ztailpacking not supported: %w", ErrNotImplemented)
+	}
+	if h.Advise&disk.ZAdviseFragmentPcluster != 0 {
+		return h, fmt.Errorf("fragments not supported: %w", ErrNotImplemented)
+	}
+	if h.Advise&disk.ZAdviseInterlacedPcluster != 0 {
+		return h, fmt.Errorf("interlaced pcluster not supported: %w", ErrNotImplemented)
+	}
+	if h.Advise&disk.ZAdviseBigPcluster2 != 0 {
+		return h, fmt.Errorf("big pcluster (head2) not supported: %w", ErrNotImplemented)
+	}
+	if h.AlgorithmType>>4 != 0 {
+		return h, fmt.Errorf("second compression algorithm (head2=%d) not supported: %w",
+			h.AlgorithmType>>4, ErrNotImplemented)
+	}
+	if h.AlgorithmType&0xF != 0 {
+		return h, fmt.Errorf("compression algorithm %d not supported: %w",
+			h.AlgorithmType&0xF, ErrNotImplemented)
+	}
+	return h, nil
+}

--- a/internal/zerofs/header_test.go
+++ b/internal/zerofs/header_test.go
@@ -1,0 +1,81 @@
+package zerofs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/erofs/go-erofs/internal/disk"
+)
+
+func TestParseHeaderRejectsUnsupported(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mod  func(*[disk.SizeZMapHeader]byte)
+	}{
+		{"InlinePcluster", func(b *[disk.SizeZMapHeader]byte) {
+			// advise bit 3 (ZAdviseInlinePcluster) at byte offset 4 low byte
+			b[4] = disk.ZAdviseInlinePcluster
+		}},
+		{"FragmentPcluster", func(b *[disk.SizeZMapHeader]byte) {
+			b[4] = disk.ZAdviseFragmentPcluster
+		}},
+		{"InterlacedPcluster", func(b *[disk.SizeZMapHeader]byte) {
+			b[4] = disk.ZAdviseInterlacedPcluster
+		}},
+		{"BigPcluster2", func(b *[disk.SizeZMapHeader]byte) {
+			b[4] = disk.ZAdviseBigPcluster2
+		}},
+		{"IdataSize", func(b *[disk.SizeZMapHeader]byte) {
+			b[2] = 0x10 // IdataSize low byte
+		}},
+		{"AlgoLZMA", func(b *[disk.SizeZMapHeader]byte) {
+			b[7] = disk.ComprAlgLZMA // algorithm type byte = 0x2 (LZMA in head1)
+		}},
+		{"AlgoHead2", func(b *[disk.SizeZMapHeader]byte) {
+			b[7] = 0x10 // head2 algorithm = 1, head1 = 0
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var b [disk.SizeZMapHeader]byte
+			tc.mod(&b)
+			_, err := ParseHeader(b[:])
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !errors.Is(err, ErrNotImplemented) {
+				t.Fatalf("expected ErrNotImplemented, got %v", err)
+			}
+		})
+	}
+}
+
+func TestParseHeaderAcceptsZero(t *testing.T) {
+	var b [disk.SizeZMapHeader]byte
+	h, err := ParseHeader(b[:])
+	if err != nil {
+		t.Fatalf("zero header should be accepted, got %v", err)
+	}
+	if h.Advise != 0 || h.AlgorithmType != 0 {
+		t.Fatalf("decoded zero header has non-zero fields: %+v", h)
+	}
+}
+
+func TestParseHeaderAcceptsBigPcluster1(t *testing.T) {
+	// BigPcluster1 is accepted (handled by FindPclusterForOffset).
+	var b [disk.SizeZMapHeader]byte
+	b[4] = disk.ZAdviseBigPcluster1
+	h, err := ParseHeader(b[:])
+	if err != nil {
+		t.Fatalf("BigPcluster1 should be accepted, got %v", err)
+	}
+	if h.Advise&disk.ZAdviseBigPcluster1 == 0 {
+		t.Fatalf("BigPcluster1 bit lost in decode")
+	}
+}
+
+func TestParseHeaderShortBuffer(t *testing.T) {
+	_, err := ParseHeader(make([]byte, 4))
+	if err == nil {
+		t.Fatal("expected error on short buffer, got nil")
+	}
+}

--- a/internal/zerofs/lcluster.go
+++ b/internal/zerofs/lcluster.go
@@ -1,0 +1,94 @@
+package zerofs
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/erofs/go-erofs/internal/disk"
+)
+
+// LclusterEntry is the decoded form of a single logical cluster entry. Only
+// the fields valid for the entry's Type are populated.
+type LclusterEntry struct {
+	Type       uint8  // disk.ZLclusterType{Plain,Head1,Nonhead,Head2}
+	ClusterOfs uint16 // valid for PLAIN/HEAD1: byte offset within decompressed data where this lcluster begins
+	BlkAddr    uint32 // valid for PLAIN/HEAD1: physical block address of the (start of the) pcluster
+	DeltaPrev  uint16 // valid for NONHEAD: lcluster distance back to the head
+	DeltaNext  uint16 // valid for NONHEAD: lcluster distance forward to the next head (0 if unknown)
+	// CBlkCnt is non-zero only for big-pcluster NONHEAD entries: it overrides
+	// the pcluster's physical block count.
+	CBlkCnt uint16
+}
+
+// Decoder reads lcluster index entries for one compressed inode.
+type Decoder struct {
+	// Meta provides random access to the image's metadata bytes.
+	Meta io.ReaderAt
+	// IndexBase is the absolute byte offset where the lcluster index array
+	// starts (immediately after the 8-byte ZMapHeader).
+	IndexBase int64
+	// Layout is one of disk.LayoutCompressedFull or disk.LayoutCompressedCompact.
+	Layout uint8
+	// BlkSizeBits is the image's log2 block size.
+	BlkSizeBits uint8
+	// LclusterBits is BlkSizeBits + (ZMapHeader.ClusterBits & 7).
+	LclusterBits uint8
+	// Header is the parsed map header for this inode.
+	Header disk.ZMapHeader
+	// Size is the logical size of the inode in bytes.
+	Size int64
+	// NLclusters is ceil(Size / (1<<LclusterBits)).
+	NLclusters int
+}
+
+// LclusterSize returns the byte size of one logical cluster.
+func (d *Decoder) LclusterSize() int64 {
+	return int64(1) << d.LclusterBits
+}
+
+// Entry returns the decoded lcluster index entry at idx.
+func (d *Decoder) Entry(idx int) (LclusterEntry, error) {
+	if idx < 0 || idx >= d.NLclusters {
+		return LclusterEntry{}, fmt.Errorf("lcluster index %d out of range [0,%d)", idx, d.NLclusters)
+	}
+	switch d.Layout {
+	case disk.LayoutCompressedFull:
+		return d.decodeFull(idx)
+	case disk.LayoutCompressedCompact:
+		return LclusterEntry{}, fmt.Errorf("compact lcluster layout not supported: %w", ErrNotImplemented)
+	default:
+		return LclusterEntry{}, fmt.Errorf("unknown compressed layout %d", d.Layout)
+	}
+}
+
+func (d *Decoder) decodeFull(idx int) (LclusterEntry, error) {
+	var buf [disk.SizeLclusterIndex]byte
+	off := d.IndexBase + int64(idx)*disk.SizeLclusterIndex
+	if _, err := d.Meta.ReadAt(buf[:], off); err != nil {
+		return LclusterEntry{}, fmt.Errorf("read lcluster %d at %d: %w", idx, off, err)
+	}
+	var li disk.LclusterIndex
+	if _, err := binary.Decode(buf[:], binary.LittleEndian, &li); err != nil {
+		return LclusterEntry{}, fmt.Errorf("decode lcluster %d: %w", idx, err)
+	}
+	e := LclusterEntry{Type: uint8(li.Advise & disk.ZLclusterTypeMask)}
+	switch e.Type {
+	case disk.ZLclusterTypePlain, disk.ZLclusterTypeHead1:
+		e.ClusterOfs = li.ClusterOfs
+		e.BlkAddr = li.U
+	case disk.ZLclusterTypeNonhead:
+		delta0 := uint16(li.U & 0xFFFF)
+		delta1 := uint16(li.U >> 16)
+		if delta0&disk.ZLclusterD0CBlkCnt != 0 {
+			e.CBlkCnt = delta0 &^ disk.ZLclusterD0CBlkCnt
+			e.DeltaPrev = 1
+		} else {
+			e.DeltaPrev = delta0
+		}
+		e.DeltaNext = delta1
+	case disk.ZLclusterTypeHead2:
+		return LclusterEntry{}, fmt.Errorf("HEAD2 lcluster (lcn=%d): %w", idx, ErrNotImplemented)
+	}
+	return e, nil
+}

--- a/internal/zerofs/lcluster_test.go
+++ b/internal/zerofs/lcluster_test.go
@@ -1,0 +1,132 @@
+package zerofs
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/erofs/go-erofs/internal/disk"
+)
+
+// fullLayoutImage builds a synthetic lcluster index for full layout. entries
+// is the sequence of (type, clusterofs, u) tuples to encode. Returns an
+// io.ReaderAt whose offset 0 is the start of the index.
+func buildFullIndex(t *testing.T, entries []disk.LclusterIndex) *bytes.Reader {
+	t.Helper()
+	buf := make([]byte, len(entries)*disk.SizeLclusterIndex)
+	for i, e := range entries {
+		off := i * disk.SizeLclusterIndex
+		binary.LittleEndian.PutUint16(buf[off:off+2], e.Advise)
+		binary.LittleEndian.PutUint16(buf[off+2:off+4], e.ClusterOfs)
+		binary.LittleEndian.PutUint32(buf[off+4:off+8], e.U)
+	}
+	return bytes.NewReader(buf)
+}
+
+// TestFullDecodeHeadAndNonhead exercises the most common case: a HEAD1
+// followed by N NONHEAD entries.
+func TestFullDecodeHeadAndNonhead(t *testing.T) {
+	entries := []disk.LclusterIndex{
+		// lcn 0: HEAD1, clusterofs=0, pcluster blkaddr=10
+		{Advise: disk.ZLclusterTypeHead1, ClusterOfs: 0, U: 10},
+		// lcn 1: NONHEAD, delta[0]=1 (back 1 lcluster to head)
+		{Advise: disk.ZLclusterTypeNonhead, ClusterOfs: 0, U: 1},
+		// lcn 2: NONHEAD, delta[0]=2
+		{Advise: disk.ZLclusterTypeNonhead, ClusterOfs: 0, U: 2},
+		// lcn 3: HEAD1, clusterofs=0, pcluster blkaddr=20 (next pcluster)
+		{Advise: disk.ZLclusterTypeHead1, ClusterOfs: 0, U: 20},
+	}
+	r := buildFullIndex(t, entries)
+	d := &Decoder{
+		Meta:         r,
+		IndexBase:    0,
+		Layout:       disk.LayoutCompressedFull,
+		BlkSizeBits:  12,
+		LclusterBits: 12,
+		Size:         4 * 4096, // 4 lclusters worth
+		NLclusters:   4,
+	}
+	for i, want := range entries {
+		got, err := d.Entry(i)
+		if err != nil {
+			t.Fatalf("Entry(%d): %v", i, err)
+		}
+		wantType := uint8(want.Advise & disk.ZLclusterTypeMask)
+		if got.Type != wantType {
+			t.Errorf("lcn %d: type got %d want %d", i, got.Type, wantType)
+		}
+		if wantType == disk.ZLclusterTypeHead1 {
+			if got.BlkAddr != want.U {
+				t.Errorf("lcn %d: blkaddr got %d want %d", i, got.BlkAddr, want.U)
+			}
+		}
+		if wantType == disk.ZLclusterTypeNonhead {
+			if uint32(got.DeltaPrev) != want.U {
+				t.Errorf("lcn %d: delta_prev got %d want %d", i, got.DeltaPrev, want.U)
+			}
+		}
+	}
+}
+
+// TestFindPclusterForOffset checks pcluster boundary resolution across the
+// canonical HEAD..NONHEAD..NONHEAD..HEAD pattern.
+func TestFindPclusterForOffset(t *testing.T) {
+	entries := []disk.LclusterIndex{
+		{Advise: disk.ZLclusterTypeHead1, ClusterOfs: 0, U: 100},
+		{Advise: disk.ZLclusterTypeNonhead, ClusterOfs: 0, U: 1},
+		{Advise: disk.ZLclusterTypeNonhead, ClusterOfs: 0, U: 2},
+		{Advise: disk.ZLclusterTypeHead1, ClusterOfs: 0, U: 200},
+		{Advise: disk.ZLclusterTypeNonhead, ClusterOfs: 0, U: 1},
+	}
+	r := buildFullIndex(t, entries)
+	d := &Decoder{
+		Meta:         r,
+		IndexBase:    0,
+		Layout:       disk.LayoutCompressedFull,
+		BlkSizeBits:  12,
+		LclusterBits: 12,
+		Size:         5 * 4096,
+		NLclusters:   5,
+	}
+
+	// Offset 0 is in pcluster A (head=0, blkaddr=100, spans lcns 0..2).
+	pc, err := d.FindPclusterForOffset(0)
+	if err != nil {
+		t.Fatalf("FindPcluster(0): %v", err)
+	}
+	if pc.HeadLcn != 0 || pc.HeadBlk != 100 {
+		t.Errorf("offset 0: head=%d blk=%d want head=0 blk=100", pc.HeadLcn, pc.HeadBlk)
+	}
+	if pc.LogStart != 0 || pc.LogLen != 3*4096 {
+		t.Errorf("offset 0: logStart=%d logLen=%d want 0/%d", pc.LogStart, pc.LogLen, 3*4096)
+	}
+
+	// Offset in the middle of pcluster A (lcn=1).
+	pc, err = d.FindPclusterForOffset(4096 + 100)
+	if err != nil {
+		t.Fatalf("FindPcluster(4196): %v", err)
+	}
+	if pc.HeadLcn != 0 || pc.HeadBlk != 100 {
+		t.Errorf("offset 4196: head=%d blk=%d want head=0 blk=100", pc.HeadLcn, pc.HeadBlk)
+	}
+
+	// Offset at lcn=3, the head of pcluster B (blkaddr=200, spans lcns 3..4).
+	pc, err = d.FindPclusterForOffset(3 * 4096)
+	if err != nil {
+		t.Fatalf("FindPcluster(lcn=3): %v", err)
+	}
+	if pc.HeadLcn != 3 || pc.HeadBlk != 200 {
+		t.Errorf("lcn 3: head=%d blk=%d want head=3 blk=200", pc.HeadLcn, pc.HeadBlk)
+	}
+	if pc.LogStart != 3*4096 || pc.LogLen != 2*4096 {
+		t.Errorf("lcn 3: logStart=%d logLen=%d want %d/%d", pc.LogStart, pc.LogLen, 3*4096, 2*4096)
+	}
+}
+
+func TestFindPclusterCompactRejected(t *testing.T) {
+	d := &Decoder{Layout: disk.LayoutCompressedCompact, NLclusters: 1, Size: 4096, LclusterBits: 12, BlkSizeBits: 12}
+	_, err := d.Entry(0)
+	if err == nil {
+		t.Fatal("compact layout should return error")
+	}
+}

--- a/internal/zerofs/lz4.go
+++ b/internal/zerofs/lz4.go
@@ -1,0 +1,118 @@
+package zerofs
+
+import (
+	"errors"
+)
+
+// uncompressLZ4Partial decodes an LZ4 block from src into dst, stopping
+// when len(dst) bytes have been produced. It is the equivalent of the
+// upstream LZ4_decompress_safe_partial function used by the Linux EROFS
+// driver. The 0-padding compression variant places valid LZ4 data at the
+// start of one or more physical blocks and pads the remainder with zero
+// bytes — those padding bytes must never be consumed as LZ4 sequences
+// (they would decode as match-offset-0 or otherwise corrupt output).
+//
+// Returns the number of bytes written to dst (== len(dst) on success).
+//
+// LZ4 block format reference: https://github.com/lz4/lz4/blob/dev/doc/lz4_Block_format.md
+func uncompressLZ4Partial(dst, src []byte) (int, error) {
+	if len(dst) == 0 {
+		return 0, nil
+	}
+	if len(src) == 0 {
+		return 0, errLZ4ShortSrc
+	}
+
+	var si, di int
+	for di < len(dst) {
+		if si >= len(src) {
+			return 0, errLZ4ShortSrc
+		}
+		token := src[si]
+		si++
+
+		// Literal length: high nibble of token, with extension bytes if 15.
+		lLen := int(token >> 4)
+		if lLen == 15 {
+			for {
+				if si >= len(src) {
+					return 0, errLZ4ShortSrc
+				}
+				b := src[si]
+				si++
+				lLen += int(b)
+				if b != 255 {
+					break
+				}
+				if lLen > len(dst) {
+					return 0, errLZ4BadLength
+				}
+			}
+		}
+
+		// Copy literals.
+		if lLen > 0 {
+			if si+lLen > len(src) {
+				return 0, errLZ4ShortSrc
+			}
+			n := lLen
+			if di+n > len(dst) {
+				n = len(dst) - di
+			}
+			copy(dst[di:di+n], src[si:si+n])
+			si += lLen
+			di += n
+			if di >= len(dst) {
+				return di, nil
+			}
+		}
+
+		// Match offset (2 bytes, little-endian).
+		if si+2 > len(src) {
+			return 0, errLZ4ShortSrc
+		}
+		mOff := int(src[si]) | int(src[si+1])<<8
+		si += 2
+		if mOff == 0 || mOff > di {
+			return 0, errLZ4BadMatch
+		}
+
+		// Match length: low nibble of token + 4, with extension bytes if low nibble is 15.
+		mLen := int(token&0x0F) + 4
+		if int(token&0x0F) == 15 {
+			for {
+				if si >= len(src) {
+					return 0, errLZ4ShortSrc
+				}
+				b := src[si]
+				si++
+				mLen += int(b)
+				if b != 255 {
+					break
+				}
+				if mLen > len(dst) {
+					return 0, errLZ4BadLength
+				}
+			}
+		}
+
+		// Back-copy from earlier in dst. May overlap (LZ4 allows mOff < mLen);
+		// must copy byte-by-byte to support the standard RLE-style overlap
+		// pattern.
+		n := mLen
+		if di+n > len(dst) {
+			n = len(dst) - di
+		}
+		for i := 0; i < n; i++ {
+			dst[di+i] = dst[di+i-mOff]
+		}
+		di += n
+	}
+	return di, nil
+}
+
+var (
+	errLZ4ShortSrc  = errors.New("lz4: unexpected end of compressed input")
+	errLZ4BadMatch  = errors.New("lz4: invalid match offset")
+	errLZ4BadLength = errors.New("lz4: implausible length extension")
+)

--- a/internal/zerofs/pcluster.go
+++ b/internal/zerofs/pcluster.go
@@ -1,0 +1,170 @@
+package zerofs
+
+import (
+	"fmt"
+
+	"github.com/erofs/go-erofs/internal/disk"
+)
+
+// Pcluster describes one physical (compressed) cluster: where its compressed
+// bytes live, how much decompressed output it produces, and at which logical
+// file offset that decompressed output begins.
+type Pcluster struct {
+	HeadType  uint8  // disk.ZLclusterType{Plain,Head1}
+	HeadLcn   int    // lcluster index of the head
+	HeadOfs   uint16 // ClusterOfs of the head lcluster
+	HeadBlk   uint32 // physical block address of the (start of the) compressed data
+	NPhysBlks uint32 // physical (compressed) block count
+	LogStart  int64  // logical byte offset where the pcluster's decompressed output begins
+	LogLen    int64  // length of the pcluster's decompressed output in bytes
+}
+
+// FindPclusterForOffset returns the pcluster containing logical file offset
+// pos. The caller must ensure 0 <= pos < d.Size.
+func (d *Decoder) FindPclusterForOffset(pos int64) (Pcluster, error) {
+	lcsize := d.LclusterSize()
+	lcn := int(pos >> d.LclusterBits)
+	endoff := uint16(pos & (lcsize - 1))
+
+	e, err := d.Entry(lcn)
+	if err != nil {
+		return Pcluster{}, err
+	}
+
+	headLcn := lcn
+	switch e.Type {
+	case disk.ZLclusterTypePlain, disk.ZLclusterTypeHead1:
+		// If pos sits in the "preroll" region of this lcluster (the bytes
+		// before ClusterOfs belong to the previous pcluster), look back.
+		if endoff < e.ClusterOfs {
+			// Treat as if we were a NONHEAD with delta=1.
+			if lcn == 0 {
+				return Pcluster{}, fmt.Errorf("preroll on lcn 0 (clusterofs=%d, endoff=%d): %w",
+					e.ClusterOfs, endoff, ErrCorrupt)
+			}
+			headLcn, e, err = d.lookbackToHead(lcn, 1)
+			if err != nil {
+				return Pcluster{}, err
+			}
+		}
+	case disk.ZLclusterTypeNonhead:
+		if e.DeltaPrev == 0 {
+			return Pcluster{}, fmt.Errorf("NONHEAD with delta=0 at lcn=%d: %w", lcn, ErrCorrupt)
+		}
+		headLcn, e, err = d.lookbackToHead(lcn, int(e.DeltaPrev))
+		if err != nil {
+			return Pcluster{}, err
+		}
+	default:
+		return Pcluster{}, fmt.Errorf("unexpected lcluster type %d at lcn=%d", e.Type, lcn)
+	}
+
+	logStart := int64(headLcn)<<d.LclusterBits + int64(e.ClusterOfs)
+
+	// Walk forward to find the next head's start (which is this pcluster's end).
+	logEnd, cblkcntFromTail, err := d.findNextHeadStart(headLcn)
+	if err != nil {
+		return Pcluster{}, err
+	}
+	if logEnd > d.Size {
+		logEnd = d.Size
+	}
+	if logEnd <= logStart {
+		return Pcluster{}, fmt.Errorf("pcluster log range empty: start=%d end=%d (head=%d clusterofs=%d): %w",
+			logStart, logEnd, headLcn, e.ClusterOfs, ErrCorrupt)
+	}
+	logLen := logEnd - logStart
+
+	pc := Pcluster{
+		HeadType: e.Type,
+		HeadLcn:  headLcn,
+		HeadOfs:  e.ClusterOfs,
+		HeadBlk:  e.BlkAddr,
+		LogStart: logStart,
+		LogLen:   logLen,
+	}
+
+	blkSize := int64(1) << d.BlkSizeBits
+	switch e.Type {
+	case disk.ZLclusterTypePlain:
+		pc.NPhysBlks = uint32((logLen + blkSize - 1) / blkSize)
+	case disk.ZLclusterTypeHead1:
+		if d.Header.Advise&disk.ZAdviseBigPcluster1 == 0 {
+			pc.NPhysBlks = 1
+		} else {
+			if cblkcntFromTail == 0 {
+				return Pcluster{}, fmt.Errorf("big pcluster head=%d missing CBlkCnt marker: %w",
+					headLcn, ErrCorrupt)
+			}
+			pc.NPhysBlks = uint32(cblkcntFromTail)
+		}
+	}
+	if pc.NPhysBlks == 0 {
+		return Pcluster{}, fmt.Errorf("pcluster head=%d resolved to 0 physical blocks: %w", headLcn, ErrCorrupt)
+	}
+	return pc, nil
+}
+
+// lookbackToHead walks back delta lclusters from lcn until it reaches a
+// HEAD or PLAIN entry. The kernel semantics: the head pointed at by delta
+// must be HEAD/PLAIN; if not we error out as corrupt.
+func (d *Decoder) lookbackToHead(lcn, delta int) (int, LclusterEntry, error) {
+	if delta < 1 || lcn-delta < 0 {
+		return 0, LclusterEntry{}, fmt.Errorf("invalid lookback from lcn=%d by delta=%d: %w",
+			lcn, delta, ErrCorrupt)
+	}
+	headLcn := lcn - delta
+	for {
+		e, err := d.Entry(headLcn)
+		if err != nil {
+			return 0, LclusterEntry{}, err
+		}
+		switch e.Type {
+		case disk.ZLclusterTypePlain, disk.ZLclusterTypeHead1:
+			return headLcn, e, nil
+		case disk.ZLclusterTypeNonhead:
+			// Some images chain NONHEAD->NONHEAD with cumulative deltas.
+			if e.DeltaPrev == 0 {
+				return 0, LclusterEntry{}, fmt.Errorf("NONHEAD chain hit delta=0 at lcn=%d: %w",
+					headLcn, ErrCorrupt)
+			}
+			if headLcn-int(e.DeltaPrev) < 0 {
+				return 0, LclusterEntry{}, fmt.Errorf("NONHEAD chain underflow at lcn=%d delta=%d: %w",
+					headLcn, e.DeltaPrev, ErrCorrupt)
+			}
+			headLcn -= int(e.DeltaPrev)
+		default:
+			return 0, LclusterEntry{}, fmt.Errorf("lookback hit type %d at lcn=%d: %w",
+				e.Type, headLcn, ErrCorrupt)
+		}
+	}
+}
+
+// findNextHeadStart scans lclusters after headLcn looking for the start of
+// the next pcluster (a HEAD/PLAIN entry). Returns the logical byte offset at
+// which the next pcluster begins (= end of the current pcluster) and the
+// big-pcluster CBlkCnt marker if observed in a NONHEAD entry along the way.
+// If the end of the file is reached without finding another head, returns
+// d.Size as the end.
+func (d *Decoder) findNextHeadStart(headLcn int) (int64, uint16, error) {
+	var cblkcnt uint16
+	for i := headLcn + 1; i < d.NLclusters; i++ {
+		e, err := d.Entry(i)
+		if err != nil {
+			return 0, 0, err
+		}
+		switch e.Type {
+		case disk.ZLclusterTypePlain, disk.ZLclusterTypeHead1:
+			return int64(i)<<d.LclusterBits + int64(e.ClusterOfs), cblkcnt, nil
+		case disk.ZLclusterTypeNonhead:
+			if e.CBlkCnt != 0 {
+				cblkcnt = e.CBlkCnt
+			}
+		default:
+			return 0, 0, fmt.Errorf("unexpected lcluster type %d at lcn=%d in forward walk: %w",
+				e.Type, i, ErrCorrupt)
+		}
+	}
+	// Reached end of file. The pcluster runs to the file's logical end.
+	return d.Size, cblkcnt, nil
+}


### PR DESCRIPTION
This is the first in a series of patches adding compression support. I tried t split this into revieweable chunks that work as stand-alone additions.

---

Adds read support for LZ4-compressed EROFS images using the full (legacy) lcluster index layout. Compact layout, ztailpacking, fragments, big_pcluster_2, HEAD2 / LZMA / DEFLATE / Zstd remain deferred — they return clear ErrNotImplemented at read time.

New internal/zerofs package owns the z_erofs read path: map-header parsing & validation, full-layout lcluster decoding, pcluster resolution (preroll + big_pcluster_1), and a partial LZ4 block decoder that handles the EROFS LZ4_0Padding variant (leading zero inputmargin + stop-at-output-cap semantics, equivalent to the kernel's LZ4_decompress_safe_partial).

erofs.go gains parseComprCfgs, loadCompressedBlock, an image-level pcluster LRU, and the superblock check is relaxed: the ComprAlgs field is now correctly treated as a union (lz4_max_distance pre- COMPR_CFGS, an algorithm bitmap when COMPR_CFGS is set).

Tests cover the standard TestCases run through an LZ4 converter, compressibility edge cases, multi-pcluster spanning reads, plain-vs- LZ4 cross-validation, fuzz of compressed image bytes, and a deferred-feature check asserting compact-layout images error cleanly.