### PR TITLE
Fix chunk-index map alignment for inodes with xattrs

### DIFF
--- a/chunk_xattr_test.go
+++ b/chunk_xattr_test.go
@@ -1,0 +1,92 @@
+package erofs_test
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	erofs "github.com/erofs/go-erofs"
+)
+
+// TestChunkBasedXattrAlignment guards against the chunk-index map being written
+// unaligned after the xattr area on a chunk-based (external-device) inode.
+//
+// The kernel and this package's reader locate the chunk-index map at
+// ALIGN(inode_isize + xattr_isize, sizeof(chunk_index)). inode_isize is a
+// multiple of 8, so a xattr area sized 4 (mod 8) pushes the map off alignment.
+// The "user.t" = "abc" attribute makes xattr_isize == 20, so inode_isize +
+// xattr_isize is 4 (mod 8) for both compact (32) and extended (64) inodes;
+// before the fix the chunk index was written 4 bytes early and the file
+// resolved to the wrong device block.
+func TestChunkBasedXattrAlignment(t *testing.T) {
+	dataPath := filepath.Join(t.TempDir(), "data.bin")
+	df, err := os.Create(dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = df.Close() }()
+
+	var metaBuf testBuffer
+	fsys := erofs.Create(&metaBuf, erofs.WithDataFile(df))
+
+	f, err := fsys.Create("/file.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := bytes.Repeat([]byte{0xAB}, 4096) // exactly one chunk
+	if _, err := f.Write(want); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Setxattr("/file.bin", "user.t", "abc"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	dfRead, err := os.Open(dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = dfRead.Close() }()
+
+	efs, err := erofs.Open(bytes.NewReader(metaBuf.Bytes()), erofs.WithExtraDevices(dfRead))
+	if err != nil {
+		t.Fatal("Open:", err)
+	}
+
+	got, err := fs.ReadFile(efs, "file.bin")
+	if err != nil {
+		t.Fatal("ReadFile:", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("file data mismatch: chunk-index map misaligned after xattr area (got %d bytes, first=0x%02x)", len(got), firstByte(got))
+	}
+
+	// The xattr itself should round-trip.
+	fi, err := fs.Stat(efs, "file.bin")
+	if err != nil {
+		t.Fatal("Stat:", err)
+	}
+	xg, ok := fi.(interface {
+		GetXattr(string) (string, bool)
+	})
+	if !ok {
+		t.Fatal("FileInfo does not expose GetXattr")
+	}
+	if v, ok := xg.GetXattr("user.t"); !ok || v != "abc" {
+		t.Fatalf("user.t = %q (ok=%v), want %q", v, ok, "abc")
+	}
+}
+
+func firstByte(b []byte) byte {
+	if len(b) == 0 {
+		return 0
+	}
+	return b[0]
+}

--- a/layout.go
+++ b/layout.go
@@ -100,8 +100,9 @@ func (w *erofsWriter) planLayout(root *erofsEntry) {
 
 		// Recalculate trailing size now that layout is decided
 		e.trailingSize = w.calcTrailingSize(e)
+		e.chunkPad = chunkIndexPad(e)
 
-		totalInodeSize := headerSize + e.trailingSize
+		totalInodeSize := headerSize + e.chunkPad + e.trailingSize
 		// Pad to 32-byte boundary
 		if totalInodeSize%32 != 0 {
 			totalInodeSize = (totalInodeSize + 31) & ^31
@@ -122,7 +123,8 @@ func (w *erofsWriter) planLayout(root *erofsEntry) {
 				// Fall back to flat-plain (data would cross block boundary)
 				e.layout = disk.LayoutFlatPlain
 				e.trailingSize = w.calcTrailingSize(e)
-				totalInodeSize = headerSize + e.trailingSize
+				e.chunkPad = chunkIndexPad(e)
+				totalInodeSize = headerSize + e.chunkPad + e.trailingSize
 				if totalInodeSize%32 != 0 {
 					totalInodeSize = (totalInodeSize + 31) & ^31
 				}
@@ -133,6 +135,26 @@ func (w *erofsWriter) planLayout(root *erofsEntry) {
 	}
 
 	w.rootNid = root.nid
+}
+
+// chunkIndexPad returns the padding inserted between an inode's xattr area and
+// its chunk-index map so the map begins aligned to the chunk-index unit, as the
+// kernel and reader both expect:
+//
+//	pos = ALIGN(iloc + inode_isize + xattr_isize, unit) + unit*chunknr
+//
+// (see fs/erofs/data.c and loadBlock's LayoutChunkBased case). inodeCoreSize is
+// always a multiple of the unit, so only the xattr area can push the map off
+// alignment. Non-chunk layouts (inline data) are read without this alignment
+// and so must not be padded.
+func chunkIndexPad(e *erofsEntry) int {
+	if e.layout != disk.LayoutChunkBased || e.trailingSize == 0 {
+		return 0
+	}
+	if r := (inodeCoreSize(e) + e.xattrSize) % disk.SizeChunkIndex; r != 0 {
+		return disk.SizeChunkIndex - r
+	}
+	return 0
 }
 
 // calcTrailingSize returns the number of bytes following the 64-byte inode.

--- a/mkfs.go
+++ b/mkfs.go
@@ -833,6 +833,7 @@ type erofsEntry struct {
 	layout        uint8
 	compact       bool // true = 32-byte compact inode; false = 64-byte extended
 	xattrSize     int  // bytes of xattr area (0 if no xattrs)
+	chunkPad      int  // 8-byte alignment pad between xattr area and chunk-index map
 	trailingSize  int
 
 	// Data block address for flat-plain files (full-image mode)

--- a/writer.go
+++ b/writer.go
@@ -119,7 +119,7 @@ func (w *erofsWriter) newMetaBuffer() *bytes.Buffer {
 		if e.compact {
 			isz = disk.SizeInodeCompact
 		}
-		sz := isz + e.xattrSize + e.trailingSize
+		sz := isz + e.xattrSize + e.chunkPad + e.trailingSize
 		if sz%32 != 0 {
 			sz = (sz + 31) & ^31
 		}
@@ -141,7 +141,7 @@ func (w *erofsWriter) assignDataBlocks() {
 		totalMetaBytes := 0
 		for _, e := range w.entries {
 			expectedOff := int(e.nid) * 32
-			sz := inodeCoreSize(e) + e.xattrSize + e.trailingSize
+			sz := inodeCoreSize(e) + e.xattrSize + e.chunkPad + e.trailingSize
 			if sz%32 != 0 {
 				sz = (sz + 31) & ^31
 			}
@@ -197,7 +197,7 @@ func (w *erofsWriter) metadataBytes() int {
 		if curOff < expectedOff {
 			curOff = expectedOff
 		}
-		sz := inodeCoreSize(e) + e.xattrSize + e.trailingSize
+		sz := inodeCoreSize(e) + e.xattrSize + e.chunkPad + e.trailingSize
 		if rem := sz % 32; rem != 0 {
 			sz += 32 - rem
 		}
@@ -311,6 +311,13 @@ func (w *erofsWriter) writeMetadataInodes(buf io.Writer) error {
 		switch e.mode & disk.StatTypeMask {
 		case disk.StatTypeReg:
 			if e.layout == disk.LayoutChunkBased && (e.size > 0 || len(e.chunks) > 0) {
+				// Align the chunk-index map to the chunk-index unit.
+				if e.chunkPad > 0 {
+					if _, err := buf.Write(w.zeroBuf[:e.chunkPad]); err != nil {
+						return err
+					}
+					metaStart += e.chunkPad
+				}
 				if err := w.writeChunkIndexes(buf, e); err != nil {
 					return fmt.Errorf("write chunks for %s: %w", e.path, err)
 				}
@@ -347,7 +354,7 @@ func (w *erofsWriter) writeMetadataInodes(buf io.Writer) error {
 		if e.compact {
 			inodeSize = disk.SizeInodeCompact
 		}
-		totalWritten := inodeSize + e.xattrSize + e.trailingSize
+		totalWritten := inodeSize + e.xattrSize + e.chunkPad + e.trailingSize
 		if totalWritten%32 != 0 {
 			padSize := 32 - (totalWritten % 32)
 			if _, err := buf.Write(w.zeroBuf[:padSize]); err != nil {


### PR DESCRIPTION
Fixes #37.

## Problem

Chunk-based inodes store their chunk-index map aligned to `sizeof(erofs_inode_chunk_index)` (8 bytes). Both the Linux kernel erofs driver (`fs/erofs/data.c`: `pos = ALIGN(erofs_iloc + inode_isize + xattr_isize, unit)`) and this package's reader (`loadBlock`, `LayoutChunkBased`, which aligns `baseOffset` up to 8 when `unit == 8`) read the map at that aligned offset. The writer, however, emitted the chunk indexes immediately after the xattr area — which is only 4-byte aligned — and `planLayout` never accounted for the gap.

Since `inode_isize` is always a multiple of 8 and the xattr body header is 12 bytes, `inode_isize + xattr_isize` lands at `4 (mod 8)` for many name/value lengths. In those cases the kernel and reader read each chunk index 4 bytes early, and the file resolves to the wrong device block — **silent data corruption**, with no error surfaced. This only affects chunk-based inodes (metadata-only / `WithDataFile` / chunk-mapped) that also carry xattrs.

## Fix

- Add a per-entry `chunkPad` computed in `planLayout` via a new `chunkIndexPad` helper: for chunk-based inodes with a chunk-index map, pad `inode_isize + xattr_isize` up to the chunk-index unit. Inline layouts (dirents, symlink/inline file data) are read without this alignment, so they are deliberately left unpadded.
- Emit `chunkPad` zero bytes before the chunk-index map in `writeMetadataInodes`.
- Include `chunkPad` in every metadata-size computation that previously summed `inodeCoreSize + xattrSize + trailingSize`: `planLayout`, `newMetaBuffer`, `assignDataBlocks`, and `metadataBytes`, so NID assignment, data-block placement, and the superblock block count all stay consistent.

## Test

Adds `TestChunkBasedXattrAlignment` (`chunk_xattr_test.go`): writes a chunk-based file whose xattr area is sized `4 (mod 8)` (`user.t` = `"abc"`, giving `xattr_isize == 20`) and verifies the data round-trips through the reader with the data file as an extra device, plus that the xattr itself reads back. It **fails before this change** (reads the wrong block — first byte `0x00` instead of `0xAB`) and **passes after**.

`go test -run 'Test' ./...` and `go vet ./...` pass. (Note: `go test ./...` also exercises the `FuzzReadFile` seed corpus, which panics on a nil `fs.FS` from `Open` — this is pre-existing on `main` and unrelated to this change.)