### PR TITLE
Fix data loss when non-contiguous chunks share a logical chunk

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -63,7 +63,27 @@ func (w *erofsWriter) planLayout(root *erofsEntry) {
 			case len(e.chunks) > 0 || e.metadataOnly:
 				e.layout = disk.LayoutChunkBased
 				if e.contiguous {
-					e.chunkBits = w.minChunkBits(e.size)
+					// A single contiguous extent has no risk of mixing
+					// distinct physical mappings within one logical chunk,
+					// so a larger chunk size is safe and reduces the
+					// number of on-disk chunk-index entries. minChunkBits
+					// is capped at 31, so this always fits in int8.
+					e.chunkBits = int8(w.minChunkBits(e.size))
+				} else {
+					// Non-contiguous (heterogeneous) chunk lists may
+					// interleave holes and data (or different physical
+					// blocks/devices) within a span shorter than the
+					// writer's default logical chunk size. Force
+					// block-granularity chunking (chunkBits=0) so every
+					// on-disk chunk-index entry maps to exactly one
+					// physical block, matching the block-level
+					// granularity of e.chunks. Without this,
+					// writeChunkIndexes would only inspect the first raw
+					// chunk overlapping a coarser logical chunk and could
+					// silently drop real data that follows within the
+					// same logical chunk (see erofs/go-erofs data-loss
+					// bug found by FuzzChunksFromRanges).
+					e.chunkBits = 0
 				}
 			default:
 				// Full-image mode: decide inline vs plain

--- a/mkfs.go
+++ b/mkfs.go
@@ -847,9 +847,9 @@ type erofsEntry struct {
 
 	// For regular files — metadata-only mode
 	chunks       []builder.Chunk
-	contiguous   bool  // data blocks are contiguous; use large chunk size
-	chunkBits    uint8 // per-entry chunk bits (0 = use global)
-	metadataOnly bool  // chunk-based layout even without chunks
+	contiguous   bool // data blocks are contiguous; use large chunk size
+	chunkBits    int8 // per-entry chunk bits override, -1 = unset (use writer default); valid range 0-31
+	metadataOnly bool // chunk-based layout even without chunks
 
 	// For regular files — full-image mode
 	data io.Reader
@@ -1311,6 +1311,7 @@ func (fsys *Writer) fsToErofs(e *fsEntry) *erofsEntry {
 		symTarget:     e.linkTarget,
 		chunks:        e.chunks,
 		contiguous:    e.contiguous,
+		chunkBits:     -1, // unset; planLayout assigns the actual value
 		metadataOnly:  e.metadataOnly,
 		data:          data,
 		xattrs:        e.xattrs,

--- a/mkfs_test.go
+++ b/mkfs_test.go
@@ -2048,6 +2048,69 @@ func TestCopyFromDataRange(t *testing.T) {
 	})
 }
 
+// TestCopyFromDataRangeNonContiguousSmallBlockSize is a regression test for
+// a chunk-index data-loss bug: a non-contiguous chunk-based file (a hole
+// followed by real data) at a block size smaller than 4096 must read back
+// correctly. The writer's default logical chunk size is derived from the
+// block size (floored to at least 4096 bytes), not from the source's
+// actual extent granularity, so a hole and the data that follows it can
+// both fall within a single logical chunk. writeChunkIndexes only
+// inspected the first raw chunk covering that window and treated the
+// entire span as a hole, silently discarding the real data that followed.
+func TestCopyFromDataRangeNonContiguousSmallBlockSize(t *testing.T) {
+	const blockSize = 1024
+	const deviceBlocks = 17
+
+	pattern := make([]byte, deviceBlocks*blockSize)
+	for i := range pattern {
+		pattern[i] = byte(i) ^ 0x5A
+	}
+
+	// File layout: a 1024-byte hole, then 1024 bytes of real data at
+	// physical block 0. Both chunks fit within one 4096-byte logical
+	// chunk (the writer's default chunk size floor when blockSize <
+	// 4096), so they must not be coalesced into a single chunk-index
+	// entry.
+	src := &dataRangerFS{
+		deviceBlocks: deviceBlocks,
+		file: &dataRangerFileInfo{
+			name: "sparse.bin",
+			size: blockSize * 2,
+			ranges: []erofs.DataRange{
+				{Offset: -1, Size: blockSize},
+				{Device: 0, Offset: 0, Size: blockSize},
+			},
+		},
+	}
+
+	var buf testBuffer
+	w := erofs.Create(&buf, erofs.WithBlockSize(blockSize))
+	if err := w.CopyFrom(src, erofs.MetadataOnly()); err != nil {
+		t.Fatal("CopyFrom:", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()), erofs.WithExtraDevices(bytes.NewReader(pattern)))
+	if err != nil {
+		t.Fatal("Open:", err)
+	}
+
+	want := make([]byte, blockSize*2)
+	copy(want[blockSize:], pattern[:blockSize])
+
+	got, err := fs.ReadFile(efs, "sparse.bin")
+	if err != nil {
+		t.Fatal("ReadFile:", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("content mismatch (chunk-index coalescing dropped real data): got % x, want % x", got, want)
+	}
+}
+
 // TestChunksFromRangesValidation verifies that chunksFromRanges rejects
 // invalid DataRange inputs instead of silently producing corrupt chunk entries.
 func TestChunksFromRangesValidation(t *testing.T) {

--- a/writer.go
+++ b/writer.go
@@ -49,9 +49,15 @@ func inodeCoreSize(e *erofsEntry) int {
 
 // entryChunkBits returns the chunk bits for a specific entry.
 // Contiguous entries use a larger chunk size to minimize chunk indexes.
+// Non-contiguous entries have chunkBits explicitly forced to 0 by
+// planLayout so that writeChunkIndexes never coalesces multiple distinct
+// physical mappings (data at different blocks/devices, or holes) into a
+// single on-disk chunk-index entry. e.chunkBits is -1 until planLayout
+// assigns it (0 is itself a valid override, so it cannot double as the
+// "unset" sentinel).
 func (w *erofsWriter) entryChunkBits(e *erofsEntry) uint8 {
-	if e.chunkBits > 0 {
-		return e.chunkBits
+	if e.chunkBits >= 0 {
+		return uint8(e.chunkBits)
 	}
 	return w.chunkBits
 }


### PR DESCRIPTION
writeChunkIndexes only inspected the first raw chunk overlapping a logical chunk-index window, so a hole followed by real data within the same window silently dropped the data. This happened whenever block size < 4096 and a non-contiguous chunk-based file's extents were smaller than the default logical chunk size (e.g. CopyFrom (MetadataOnly()) on a small sparse file).

Force block-granularity chunking (chunkBits=0) for non-contiguous entries so every chunk-index entry maps to exactly one physical block. Contiguous entries are unaffected.

Also collapses erofsEntry's chunkBits uint8 + separate "set" bool into a single int8 using -1 as the unset sentinel, matching the existing holeOffset=-1 convention.