### PR TITLE
Fix setuid/setgid/sticky bits dropped on read and in Mkdir

### DIFF
--- a/erofs.go
+++ b/erofs.go
@@ -83,6 +83,9 @@ var (
 //	InodeInfo:  Ino() uint64, Nlink() uint64
 //	DeviceInfo: Rdev() uint64
 //	Xattrs:     GetAllXattr() map[string]string, GetXattr(string) (string, bool)
+//
+// Mode has no accessor interface: use [fs.FileInfo.Mode], which returns the
+// same value, including the setuid, setgid and sticky bits.
 type Stat struct {
 	Mode        fs.FileMode
 	Size        int64
@@ -1005,7 +1008,7 @@ func (b *file) readInfo() (ino *inode, err error) {
 			inodeLayout: layout,
 			inodeData:   di.InodeData,
 			size:        int64(di.Size),
-			mode:        (fs.FileMode(di.Mode) & ^fs.ModeType) | b.ftype,
+			mode:        (disk.EroFSModeToGoFileMode(di.Mode) & ^fs.ModeType) | b.ftype,
 			rawMode:     di.Mode,
 			uid:         uint32(di.UID),
 			gid:         uint32(di.GID),
@@ -1026,7 +1029,7 @@ func (b *file) readInfo() (ino *inode, err error) {
 			inodeLayout: layout,
 			inodeData:   di.InodeData,
 			size:        int64(di.Size),
-			mode:        (fs.FileMode(di.Mode) & ^fs.ModeType) | b.ftype,
+			mode:        (disk.EroFSModeToGoFileMode(di.Mode) & ^fs.ModeType) | b.ftype,
 			rawMode:     di.Mode,
 			uid:         di.UID,
 			gid:         di.GID,

--- a/erofs_test.go
+++ b/erofs_test.go
@@ -32,6 +32,7 @@ func TestErofs(t *testing.T) {
 		{"Basic", erofstest.Basic, nil},
 		{"FileSizes", erofstest.FileSizes, nil},
 		{"UIDGIDValues", erofstest.UIDGIDValues, nil},
+		{"SpecialModeBits", erofstest.SpecialModeBits, nil},
 		{"LongXattrs", erofstest.LongXattrs, erofstest.XattrPrefixFlags()},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/erofstest/check.go
+++ b/internal/erofstest/check.go
@@ -2,6 +2,7 @@ package erofstest
 
 import (
 	"io/fs"
+	"path"
 	"testing"
 
 	"github.com/erofs/go-erofs"
@@ -66,6 +67,84 @@ func CheckDevice(t testing.TB, fsys fs.FS, name string, ftype fs.FileMode, rdev 
 	}
 	if st.Rdev != rdev {
 		t.Errorf("%s: rdev %d, want %d", name, st.Rdev, rdev)
+	}
+}
+
+// CheckMode verifies that the named path has the expected [fs.FileMode],
+// including the setuid, setgid and sticky bits. Symlinks are not followed.
+//
+// The mode is checked on every path that reports one: Lstat, Stat, the
+// parent directory's [fs.DirEntry] (as used by fs.WalkDir) and
+// Sys().(*erofs.Stat).Mode, which must all agree.
+func CheckMode(t testing.TB, fsys fs.FS, name string, want fs.FileMode) {
+	t.Helper()
+
+	lfs, ok := fsys.(lstatFS)
+	if !ok {
+		t.Errorf("FS does not implement Lstat")
+		return
+	}
+	fi, err := lfs.Lstat(name)
+	if err != nil {
+		t.Errorf("lstat %s: %v", name, err)
+		return
+	}
+	checkInfoMode(t, "Lstat("+name+")", fi, want)
+
+	// Stat follows symlinks, so it reports the target's mode instead.
+	if want&fs.ModeSymlink == 0 {
+		fi, err := fs.Stat(fsys, name)
+		if err != nil {
+			t.Errorf("stat %s: %v", name, err)
+		} else {
+			checkInfoMode(t, "Stat("+name+")", fi, want)
+		}
+	}
+
+	ents, err := fs.ReadDir(fsys, path.Dir(name))
+	if err != nil {
+		t.Errorf("readdir %s: %v", path.Dir(name), err)
+		return
+	}
+	base := path.Base(name)
+	for _, ent := range ents {
+		if ent.Name() != base {
+			continue
+		}
+		if got := ent.Type(); got != want&fs.ModeType {
+			t.Errorf("DirEntry(%s).Type() = %v, want %v", name, got, want&fs.ModeType)
+		}
+		fi, err := ent.Info()
+		if err != nil {
+			t.Errorf("DirEntry(%s).Info(): %v", name, err)
+			return
+		}
+		checkInfoMode(t, "DirEntry("+name+").Info()", fi, want)
+		return
+	}
+	t.Errorf("%s: not listed in %s", name, path.Dir(name))
+}
+
+// checkInfoMode verifies fi.Mode() against want and against the raw mode in
+// Sys(), which callers may use instead.
+func checkInfoMode(t testing.TB, what string, fi fs.FileInfo, want fs.FileMode) {
+	t.Helper()
+
+	got := fi.Mode()
+	if got != want {
+		t.Errorf("%s: mode %v (%#o), want %v (%#o)", what, got, uint32(got), want, uint32(want))
+	}
+	if fi.IsDir() != want.IsDir() {
+		t.Errorf("%s: IsDir() = %v, want %v", what, fi.IsDir(), want.IsDir())
+	}
+	st, ok := fi.Sys().(*erofs.Stat)
+	if !ok {
+		t.Errorf("%s: expected *erofs.Stat from Sys(), got %T", what, fi.Sys())
+		return
+	}
+	if st.Mode != got {
+		t.Errorf("%s: Mode() = %v (%#o) disagrees with Sys().Mode = %v (%#o)",
+			what, got, uint32(got), st.Mode, uint32(st.Mode))
 	}
 }
 

--- a/internal/erofstest/testcase.go
+++ b/internal/erofstest/testcase.go
@@ -321,6 +321,54 @@ var LongXattrs TestCase = &testCase{
 	},
 }
 
+// SpecialModeBits checks that setuid, setgid and sticky bits survive the
+// round trip into fs.FileInfo.Mode, and that the mode reported by Mode() is
+// a well-formed fs.FileMode (no raw on-disk bits) for ordinary entries too.
+var SpecialModeBits TestCase = &testCase{
+	tar: func() WriterToTar {
+		tc := TarContext{}.WithModTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+		return TarAll(
+			tc.Dir("/bin", 0755),
+			tc.File("/bin/su", []byte("setuid\n"), 0755|fs.ModeSetuid),
+			tc.File("/bin/wall", []byte("setgid\n"), 0755|fs.ModeSetgid),
+			tc.File("/bin/all-bits", []byte("all\n"), 0700|fs.ModeSetuid|fs.ModeSetgid|fs.ModeSticky),
+			tc.File("/bin/plain", []byte("plain\n"), 0644),
+			tc.Symlink("/bin/su", "/bin/su-link"),
+			tc.Dir("/tmp", 0777|fs.ModeSticky),
+			tc.Dir("/var", 0775|fs.ModeSetgid),
+			tc.Dir("/dev", 0755),
+			tc.Device("/dev/null", fs.ModeCharDevice, 1, 3),
+			tc.Device("/dev/loop0", fs.ModeDevice, 7, 0),
+			tc.Device("/dev/initctl", fs.ModeNamedPipe, 0, 0),
+		)
+	},
+	verify: func(t testing.TB, fsys fs.FS) {
+		t.Helper()
+
+		CheckMode(t, fsys, "bin/su", 0755|fs.ModeSetuid)
+		CheckMode(t, fsys, "bin/wall", 0755|fs.ModeSetgid)
+		CheckMode(t, fsys, "bin/all-bits", 0700|fs.ModeSetuid|fs.ModeSetgid|fs.ModeSticky)
+		CheckMode(t, fsys, "bin/plain", 0644)
+		CheckMode(t, fsys, "bin/su-link", 0777|fs.ModeSymlink)
+		CheckMode(t, fsys, "bin", 0755|fs.ModeDir)
+		CheckMode(t, fsys, "tmp", 0777|fs.ModeDir|fs.ModeSticky)
+		CheckMode(t, fsys, "var", 0775|fs.ModeDir|fs.ModeSetgid)
+		CheckMode(t, fsys, "dev/null", 0600|fs.ModeDevice|fs.ModeCharDevice)
+		CheckMode(t, fsys, "dev/loop0", 0600|fs.ModeDevice)
+		CheckMode(t, fsys, "dev/initctl", 0600|fs.ModeNamedPipe)
+
+		// The natural "copy this out to disk" path: os.Chmod only applies
+		// setuid/setgid/sticky when the fs.Mode* flags are set.
+		fi, err := fs.Stat(fsys, "bin/su")
+		if err != nil {
+			t.Fatalf("stat bin/su: %v", err)
+		}
+		if fi.Mode()&fs.ModeSetuid == 0 {
+			t.Errorf("bin/su: mode %v (%#o) has no fs.ModeSetuid", fi.Mode(), uint32(fi.Mode()))
+		}
+	},
+}
+
 // FileSizes tests files at layout-significant size boundaries:
 //   - 4096 bytes: exactly one block
 //   - 4097 bytes: just over one block (exercises partial second block)

--- a/mkfs.go
+++ b/mkfs.go
@@ -216,15 +216,17 @@ func (fsys *Writer) Create(name string) (*File, error) {
 	return f, nil
 }
 
-// Mkdir creates a directory. Only permission bits from perm are used;
-// type bits are forced to directory. Mkdir("/", perm) sets root permissions.
+// Mkdir creates a directory. Only permission bits from perm are used,
+// including setuid, setgid and sticky as os.Mkdir does; type bits are forced
+// to directory. Mkdir("/", perm) sets root permissions.
 func (fsys *Writer) Mkdir(name string, perm fs.FileMode) error {
 	if fsys.wErr != nil {
 		return fsys.wErr
 	}
+	dirMode := disk.StatTypeDir | goModeToUnixMode(perm)&0o7777
 	name = cleanPath(name)
 	if name == "/" {
-		fsys.root.mode = disk.StatTypeDir | uint16(perm.Perm())
+		fsys.root.mode = dirMode
 		return nil
 	}
 	if err := fsys.checkPath(name); err != nil {
@@ -235,7 +237,7 @@ func (fsys *Writer) Mkdir(name string, perm fs.FileMode) error {
 
 	e := &fsEntry{
 		path: name,
-		mode: disk.StatTypeDir | uint16(perm.Perm()),
+		mode: dirMode,
 	}
 	fsys.addChild(e)
 

--- a/mkfs_test.go
+++ b/mkfs_test.go
@@ -446,6 +446,84 @@ func TestCreateFSImplicitDirs(t *testing.T) {
 	}
 }
 
+// TestCreateFSSpecialModeBits verifies that setuid, setgid and sticky bits
+// written by the Writer are reported by the reader's fs.FileInfo.Mode, and
+// that plain entries come back as well-formed fs.FileMode values with no raw
+// on-disk bits left in them.
+func TestCreateFSSpecialModeBits(t *testing.T) {
+	var buf testBuffer
+	fsys := erofs.Create(&buf)
+
+	for _, f := range []struct {
+		name string
+		mode fs.FileMode
+	}{
+		{"/su", 0755 | fs.ModeSetuid},
+		{"/wall", 0755 | fs.ModeSetgid},
+		{"/all-bits", 0700 | fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky},
+		{"/plain", 0644},
+	} {
+		fh, err := fsys.Create(f.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := fh.Write([]byte(f.name)); err != nil {
+			t.Fatal(err)
+		}
+		if err := fh.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := fsys.Chmod(f.name, f.mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := fsys.Mkdir("/tmp", 0777|fs.ModeSticky); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Mkdir("/var", 0775|fs.ModeSetgid); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Symlink("/su", "/su-link"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Mknod("/null", disk.StatTypeChrdev|0666, 0x0103); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsys.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("EroFS:", err)
+	}
+
+	erofstest.CheckMode(t, efs, "su", 0755|fs.ModeSetuid)
+	erofstest.CheckMode(t, efs, "wall", 0755|fs.ModeSetgid)
+	erofstest.CheckMode(t, efs, "all-bits", 0700|fs.ModeSetuid|fs.ModeSetgid|fs.ModeSticky)
+	erofstest.CheckMode(t, efs, "plain", 0644)
+	erofstest.CheckMode(t, efs, "tmp", 0777|fs.ModeDir|fs.ModeSticky)
+	erofstest.CheckMode(t, efs, "var", 0775|fs.ModeDir|fs.ModeSetgid)
+	erofstest.CheckMode(t, efs, "su-link", 0777|fs.ModeSymlink)
+	erofstest.CheckMode(t, efs, "null", 0666|fs.ModeDevice|fs.ModeCharDevice)
+
+	// Writer and reader must agree on the mode they report for an entry.
+	wfi, err := fsys.Stat("/su")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rfi, err := fs.Stat(efs, "su")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wfi.Mode() != rfi.Mode() {
+		t.Errorf("su: writer mode %v (%#o), reader mode %v (%#o)",
+			wfi.Mode(), uint32(wfi.Mode()), rfi.Mode(), uint32(rfi.Mode()))
+	}
+}
+
 // TestCreateFSEmpty verifies that an empty FS produces a valid image.
 func TestCreateFSEmpty(t *testing.T) {
 	var buf testBuffer


### PR DESCRIPTION
 * Preserve setuid/setgid/sticky bits in Writer.Mkdir

   Mkdir built the entry mode from perm.Perm(), which keeps only the low 9
   bits, so S_ISUID/S_ISGID/S_ISVTX passed by the caller were silently
   dropped -- a directory created as 0777|fs.ModeSticky landed on disk as
   0777. os.Mkdir applies those bits (via syscallMode), and Writer.Chmod
   already does too through goModeToUnixMode, so Mkdir was the odd one out.

   Use goModeToUnixMode(perm) & 0o7777 for both the root and non-root cases.

   Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
   Signed-off-by: Scott Moser <smoser@brickies.net>

 * Fix FileInfo.Mode() dropping setuid/setgid/sticky on the read path

   (*file).readInfo built the fs.FileMode by pasting the raw 16-bit on-disk
   i_mode into the low bits and OR-ing in only the Go type flag:

       mode: (fs.FileMode(di.Mode) & ^fs.ModeType) | b.ftype

   S_ISUID/S_ISGID/S_ISVTX land at bits 9-11 and S_IFMT at 12-15, none of
   which Go assigns, so fs.ModeSetuid/ModeSetgid/ModeSticky were never set
   and stray bits were: a plain 0644 file came back as 0o100644. Both are
   invisible in the obvious places, since String() ignores the stray bits
   and Perm() masks them off -- the mode prints correctly and compares
   wrongly.

   The practical effect is that os.Chmod(dst, info.Mode()), the natural way
   to copy an entry out of an image, drops the bits entirely: syscallMode
   adds S_ISUID/S_ISGID/S_ISVTX only when the corresponding fs.Mode* flags
   are set. Anything walking an image and reproducing it elsewhere silently
   un-setuids su/passwd/mount and un-stickies /tmp.

   Use disk.EroFSModeToGoFileMode, which the writer's FileInfo and Stat.Mode
   already go through, while keeping the type bits from the directory entry
   so IsDir(), symlink resolution and the IsRegular() check in statInfo
   behave exactly as before.

   Add CheckMode, which asserts a mode via Lstat, Stat and the parent's
   fs.DirEntry.Type()/Info() (the fs.WalkDir path), and requires each
   FileInfo.Mode() to agree with Sys().(*erofs.Stat).Mode. It is driven from
   a new SpecialModeBits test case run against the mkfs.erofs converters
   (compact inodes) and from TestCreateFSSpecialModeBits, which round-trips
   through the Writer (extended inodes). Both fail before this change.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
