### PR TITLE
Add remove functions for merging overlays

### DIFF
--- a/erofs.go
+++ b/erofs.go
@@ -66,6 +66,11 @@ var (
 	// a directory.
 	ErrIsDirectory = errors.New("is a directory")
 
+	// ErrDirNotEmpty is returned by Remove when the named path is a
+	// non-empty directory. Mirrors the behavior of os.Remove (which returns
+	// ENOTEMPTY).
+	ErrDirNotEmpty = errors.New("directory not empty")
+
 	// ErrLoop is returned when too many symlinks are encountered during
 	// path resolution.
 	ErrLoop = fmt.Errorf("too many symlinks: %w", ErrInvalid)

--- a/mkfs.go
+++ b/mkfs.go
@@ -749,6 +749,41 @@ func (fsys *Writer) Link(oldname, newname string) error {
 	return nil
 }
 
+// Remove removes the named path from the writer's tree. It mirrors the
+// semantics of [os.Remove]: it is non-recursive, returns [fs.ErrNotExist]
+// (wrapped in [fs.PathError]) if the path does not exist, and returns
+// [ErrDirNotEmpty] if the path is a non-empty directory.
+//
+// Removing one name of a hard-linked file only removes that name and
+// decrements the shared fsInode's link count; the underlying data and any
+// other names referring to it are unaffected.
+//
+// Remove cannot be used to delete the root.
+func (fsys *Writer) Remove(name string) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
+	name = cleanPath(name)
+	if name == "/" {
+		return &fs.PathError{Op: "remove", Path: name, Err: fmt.Errorf("cannot remove root")}
+	}
+
+	e, err := fsys.resolveEntry("remove", name)
+	if err != nil {
+		return err
+	}
+	if e.ino.mode&disk.StatTypeMask == disk.StatTypeDir {
+		for _, c := range e.children {
+			if !c.removed {
+				return &fs.PathError{Op: "remove", Path: name, Err: ErrDirNotEmpty}
+			}
+		}
+	}
+
+	fsys.remove(name)
+	return nil
+}
+
 // --- File methods ---
 
 // Write appends data to the file.

--- a/mkfs.go
+++ b/mkfs.go
@@ -1,6 +1,7 @@
 package erofs
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -780,6 +781,40 @@ func (fsys *Writer) Remove(name string) error {
 		}
 	}
 
+	fsys.remove(name)
+	return nil
+}
+
+// RemoveAll removes the named path and any children it contains. Removal is
+// recursive, and it returns nil (no error) if the path does not exist.
+// Unlike a simple absence, a path that traverses a non-directory ancestor
+// (e.g. removing "/file/child" when "/file" is a regular file) still
+// returns ErrNotDirectory, matching [Writer.Remove].
+//
+// As with hard-linked files under [Writer.Remove], removing a name only
+// decrements the shared fsInode's link count; data referenced by surviving
+// names elsewhere in the tree is unaffected.
+//
+// RemoveAll cannot be used to delete the root.
+func (fsys *Writer) RemoveAll(name string) error {
+	if fsys.wErr != nil {
+		return fsys.wErr
+	}
+	name = cleanPath(name)
+	if name == "/" {
+		return &fs.PathError{Op: "removeall", Path: name, Err: fmt.Errorf("cannot remove root")}
+	}
+
+	_, err := fsys.resolveEntry("removeall", name)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	// The internal remove() is already recursive for directories (it calls
+	// removeSubtree), so no per-child empty check is needed here.
 	fsys.remove(name)
 	return nil
 }

--- a/mkfs_remove_test.go
+++ b/mkfs_remove_test.go
@@ -4,51 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"io/fs"
-	"path"
 	"testing"
 
 	erofs "github.com/erofs/go-erofs"
 	"github.com/erofs/go-erofs/internal/erofstest"
 )
-
-// removeAll is a caller-side recursive remove implemented on top of
-// Writer.Remove + fs.ReadDir. It is duplicated in the test rather than
-// added to the public API to demonstrate that recursive removal does not
-// require a dedicated writer method.
-func removeAll(w *erofs.Writer, p string) error {
-	entries, err := fs.ReadDir(w, cleanForReadDir(p))
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil
-		}
-		// Not a directory: fall through to Remove below.
-		var pe *fs.PathError
-		if !errors.As(err, &pe) {
-			return err
-		}
-	}
-	for _, e := range entries {
-		if err := removeAll(w, path.Join(p, e.Name())); err != nil {
-			return err
-		}
-	}
-	if err := w.Remove(p); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return err
-	}
-	return nil
-}
-
-// cleanForReadDir converts an absolute writer path to the form
-// fs.ReadDir expects (relative, no leading slash; "." for root).
-func cleanForReadDir(p string) string {
-	if p == "/" || p == "" {
-		return "."
-	}
-	if len(p) > 0 && p[0] == '/' {
-		return p[1:]
-	}
-	return p
-}
 
 // TestWriterRemoveFile verifies Remove deletes a regular file and the
 // resulting image contains no trace of it.
@@ -346,10 +306,9 @@ func TestWriterRemoveHardlinkAllAliases(t *testing.T) {
 	erofstest.CheckDirEntries(t, efs, ".", []string{})
 }
 
-// TestCallerRecursiveRemove verifies that callers can implement recursive
-// removal on top of Writer.Remove + fs.ReadDir without a dedicated writer
-// method.
-func TestCallerRecursiveRemove(t *testing.T) {
+// TestWriterRemoveAllRecursive verifies RemoveAll deletes a directory and
+// all of its descendants, leaving unrelated paths untouched.
+func TestWriterRemoveAllRecursive(t *testing.T) {
 	var buf testBuffer
 	w := erofs.Create(&buf)
 
@@ -383,8 +342,8 @@ func TestCallerRecursiveRemove(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := removeAll(w, "/dir"); err != nil {
-		t.Fatal("removeAll:", err)
+	if err := w.RemoveAll("/dir"); err != nil {
+		t.Fatal("RemoveAll:", err)
 	}
 
 	if err := w.Close(); err != nil {
@@ -400,20 +359,79 @@ func TestCallerRecursiveRemove(t *testing.T) {
 	erofstest.CheckDirEntries(t, efs, "other", []string{"keep"})
 }
 
-// TestCallerRecursiveRemoveMissing verifies the caller-side recursive
-// pattern is a no-op on a path that does not exist.
-func TestCallerRecursiveRemoveMissing(t *testing.T) {
+// TestWriterRemoveAllMissing verifies RemoveAll is a no-op (returns nil) on
+// a path that does not exist.
+func TestWriterRemoveAllMissing(t *testing.T) {
 	var buf testBuffer
 	w := erofs.Create(&buf)
-	if err := removeAll(w, "/does/not/exist"); err != nil {
-		t.Fatalf("removeAll missing: got %v, want nil", err)
+	if err := w.RemoveAll("/does/not/exist"); err != nil {
+		t.Fatalf("RemoveAll missing: got %v, want nil", err)
 	}
 }
 
-// TestCallerRecursiveRemoveHardlinkInside verifies that the caller-side
-// recursive pattern over a subtree containing a hardlink alias correctly
-// updates the canonical entry's link count when the alias is removed.
-func TestCallerRecursiveRemoveHardlinkInside(t *testing.T) {
+// TestWriterRemoveAllNonDirectoryAncestor verifies RemoveAll returns
+// ErrNotDirectory (not nil) when a path component along the way is an
+// existing non-directory, matching Writer.Remove instead of silently
+// treating it as a missing path.
+func TestWriterRemoveAllNonDirectoryAncestor(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	f, err := w.Create("/file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	err = w.RemoveAll("/file/child")
+	if !errors.Is(err, erofs.ErrNotDirectory) {
+		t.Fatalf("RemoveAll through non-directory: got %v, want ErrNotDirectory", err)
+	}
+}
+
+// TestWriterRemoveAllRoot verifies RemoveAll cannot delete "/".
+func TestWriterRemoveAllRoot(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+	if err := w.RemoveAll("/"); err == nil {
+		t.Fatal("expected error removing root")
+	}
+}
+
+// TestWriterRemoveAllFile verifies RemoveAll works on a single regular
+// file, just like Remove.
+func TestWriterRemoveAllFile(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	f, err := w.Create("/drop.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.RemoveAll("/drop.txt"); err != nil {
+		t.Fatal("RemoveAll file:", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	erofstest.CheckDirEntries(t, efs, ".", []string{})
+}
+
+// TestWriterRemoveAllHardlinkInside verifies that RemoveAll over a subtree
+// containing a hardlink alias correctly updates the canonical entry's link
+// count when the alias is removed.
+func TestWriterRemoveAllHardlinkInside(t *testing.T) {
 	var buf testBuffer
 	w := erofs.Create(&buf)
 
@@ -437,7 +455,7 @@ func TestCallerRecursiveRemoveHardlinkInside(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := removeAll(w, "/scratch"); err != nil {
+	if err := w.RemoveAll("/scratch"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/mkfs_remove_test.go
+++ b/mkfs_remove_test.go
@@ -1,0 +1,457 @@
+package erofs_test
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"path"
+	"testing"
+
+	erofs "github.com/erofs/go-erofs"
+	"github.com/erofs/go-erofs/internal/erofstest"
+)
+
+// removeAll is a caller-side recursive remove implemented on top of
+// Writer.Remove + fs.ReadDir. It is duplicated in the test rather than
+// added to the public API to demonstrate that recursive removal does not
+// require a dedicated writer method.
+func removeAll(w *erofs.Writer, p string) error {
+	entries, err := fs.ReadDir(w, cleanForReadDir(p))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		// Not a directory: fall through to Remove below.
+		var pe *fs.PathError
+		if !errors.As(err, &pe) {
+			return err
+		}
+	}
+	for _, e := range entries {
+		if err := removeAll(w, path.Join(p, e.Name())); err != nil {
+			return err
+		}
+	}
+	if err := w.Remove(p); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// cleanForReadDir converts an absolute writer path to the form
+// fs.ReadDir expects (relative, no leading slash; "." for root).
+func cleanForReadDir(p string) string {
+	if p == "/" || p == "" {
+		return "."
+	}
+	if len(p) > 0 && p[0] == '/' {
+		return p[1:]
+	}
+	return p
+}
+
+// TestWriterRemoveFile verifies Remove deletes a regular file and the
+// resulting image contains no trace of it.
+func TestWriterRemoveFile(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	f, err := w.Create("/keep.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("keep\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	f2, err := w.Create("/drop.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f2.Write([]byte("drop\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f2.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := w.Remove("/drop.txt"); err != nil {
+		t.Fatal("Remove:", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal("Close:", err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("Open:", err)
+	}
+	erofstest.CheckFile(t, efs, "keep.txt", "keep\n")
+	erofstest.CheckDirEntries(t, efs, ".", []string{"keep.txt"})
+}
+
+// TestWriterRemoveEmptyDir verifies that an empty directory can be removed.
+func TestWriterRemoveEmptyDir(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	if err := w.Mkdir("/a", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Mkdir("/b", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Remove("/b"); err != nil {
+		t.Fatal("Remove empty dir:", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	erofstest.CheckDirEntries(t, efs, ".", []string{"a"})
+}
+
+// TestWriterRemoveNonEmptyDirFails verifies that Remove returns an error
+// for a directory that still has children.
+func TestWriterRemoveNonEmptyDirFails(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	if err := w.Mkdir("/dir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := w.Create("/dir/child")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	err = w.Remove("/dir")
+	if err == nil {
+		t.Fatal("expected error removing non-empty directory")
+	}
+	var pe *fs.PathError
+	if !errors.As(err, &pe) {
+		t.Fatalf("error is not *fs.PathError: %T %v", err, err)
+	}
+	if !errors.Is(err, erofs.ErrDirNotEmpty) {
+		t.Fatalf("error is not ErrDirNotEmpty: %v", err)
+	}
+}
+
+// TestWriterRemoveMissingReturnsErrNotExist verifies Remove signals
+// fs.ErrNotExist for a path that was never added.
+func TestWriterRemoveMissingReturnsErrNotExist(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	err := w.Remove("/missing")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("Remove missing: got %v, want fs.ErrNotExist", err)
+	}
+}
+
+// TestWriterRemoveRootFails verifies Remove cannot delete "/".
+func TestWriterRemoveRootFails(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+	if err := w.Remove("/"); err == nil {
+		t.Fatal("expected error removing root")
+	}
+}
+
+// TestWriterRemoveSymlink verifies a symlink can be removed.
+func TestWriterRemoveSymlink(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	f, err := w.Create("/target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("x\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Symlink("target", "/link"); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Remove("/link"); err != nil {
+		t.Fatal("Remove symlink:", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	erofstest.CheckDirEntries(t, efs, ".", []string{"target"})
+}
+
+// TestWriterRemoveHardlinkAlias verifies that removing an alias leaves the
+// canonical path intact with the correct nlink.
+func TestWriterRemoveHardlinkAlias(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	f, err := w.Create("/orig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("hardlink payload\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Link("/orig", "/alias1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Link("/orig", "/alias2"); err != nil {
+		t.Fatal(err)
+	}
+	// Remove one alias.
+	if err := w.Remove("/alias1"); err != nil {
+		t.Fatal("Remove alias:", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	erofstest.CheckFile(t, efs, "orig", "hardlink payload\n")
+	erofstest.CheckFile(t, efs, "alias2", "hardlink payload\n")
+	erofstest.CheckDirEntries(t, efs, ".", []string{"alias2", "orig"})
+
+	stOrig := erofstest.Stat(t, efs, "orig")
+	stAlias := erofstest.Stat(t, efs, "alias2")
+	if stOrig.Ino != stAlias.Ino {
+		t.Errorf("Ino mismatch after alias remove: orig=%d alias2=%d", stOrig.Ino, stAlias.Ino)
+	}
+	if stOrig.Nlink != 2 {
+		t.Errorf("orig nlink after alias remove: got %d, want 2", stOrig.Nlink)
+	}
+}
+
+// TestWriterRemoveHardlinkCanonicalPromotes verifies that removing the
+// canonical path of a hardlink group promotes the first surviving alias
+// to canonical (POSIX unlink semantics).
+func TestWriterRemoveHardlinkCanonicalPromotes(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	f, err := w.Create("/orig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("promote me\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Link("/orig", "/alias1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Link("/orig", "/alias2"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove the canonical entry; data should survive via the aliases.
+	if err := w.Remove("/orig"); err != nil {
+		t.Fatal("Remove canonical:", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	erofstest.CheckFile(t, efs, "alias1", "promote me\n")
+	erofstest.CheckFile(t, efs, "alias2", "promote me\n")
+	erofstest.CheckDirEntries(t, efs, ".", []string{"alias1", "alias2"})
+
+	st1 := erofstest.Stat(t, efs, "alias1")
+	st2 := erofstest.Stat(t, efs, "alias2")
+	if st1.Ino != st2.Ino {
+		t.Errorf("Ino mismatch after canonical remove: alias1=%d alias2=%d", st1.Ino, st2.Ino)
+	}
+	if st1.Nlink != 2 {
+		t.Errorf("alias1 nlink: got %d, want 2", st1.Nlink)
+	}
+}
+
+// TestWriterRemoveHardlinkAllAliases verifies removing every alias of a
+// pair drops both paths and the data along with them.
+func TestWriterRemoveHardlinkAllAliases(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	f, err := w.Create("/orig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("doomed\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Link("/orig", "/alias"); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Remove("/orig"); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Remove("/alias"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	erofstest.CheckDirEntries(t, efs, ".", []string{})
+}
+
+// TestCallerRecursiveRemove verifies that callers can implement recursive
+// removal on top of Writer.Remove + fs.ReadDir without a dedicated writer
+// method.
+func TestCallerRecursiveRemove(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	if err := w.Mkdir("/dir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Mkdir("/dir/sub", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{"/dir/a", "/dir/b", "/dir/sub/c"} {
+		f, err := w.Create(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write([]byte(p + "\n")); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := w.Mkdir("/other", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := w.Create("/other/keep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeAll(w, "/dir"); err != nil {
+		t.Fatal("removeAll:", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	erofstest.CheckDirEntries(t, efs, ".", []string{"other"})
+	erofstest.CheckDirEntries(t, efs, "other", []string{"keep"})
+}
+
+// TestCallerRecursiveRemoveMissing verifies the caller-side recursive
+// pattern is a no-op on a path that does not exist.
+func TestCallerRecursiveRemoveMissing(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+	if err := removeAll(w, "/does/not/exist"); err != nil {
+		t.Fatalf("removeAll missing: got %v, want nil", err)
+	}
+}
+
+// TestCallerRecursiveRemoveHardlinkInside verifies that the caller-side
+// recursive pattern over a subtree containing a hardlink alias correctly
+// updates the canonical entry's link count when the alias is removed.
+func TestCallerRecursiveRemoveHardlinkInside(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf)
+
+	if err := w.Mkdir("/keep", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := w.Create("/keep/orig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("payload\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Mkdir("/scratch", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Link("/keep/orig", "/scratch/alias"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeAll(w, "/scratch"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	erofstest.FsckErofsBytes(t, buf.Bytes())
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	erofstest.CheckFile(t, efs, "keep/orig", "payload\n")
+	st := erofstest.Stat(t, efs, "keep/orig")
+	if st.Nlink != 1 {
+		t.Errorf("keep/orig nlink after scratch removal: got %d, want 1", st.Nlink)
+	}
+}


### PR DESCRIPTION
Matching function signatures on Go's os.Root. The removals an be used when merging overlays consumed from tar streams.