### PR TITLE
Add lz4 compression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A Go library for reading and creating [EROFS](https://erofs.docs.kernel.org/) fi
 
 ## Features
 
-- **Read** EROFS images through Go's `fs.FS` interface
-- **Create** EROFS images from directories or any `fs.FS`
+- **Read** EROFS images through Go's `fs.FS` interface, including LZ4-compressed images
+- **Create** EROFS images from directories or any `fs.FS`, with optional LZ4 compression
 - **Merge** multiple filesystem sources with overlay whiteout support
 - **Metadata-only** mode for container layer indexing (chunk-based references to original data)
-- Pure Go, no CGO — uses only the standard library
+- Pure Go, no CGO — only dependency is `github.com/pierrec/lz4/v4` for LZ4 block compression
 
 ### Status
 
@@ -20,7 +20,7 @@ A Go library for reading and creating [EROFS](https://erofs.docs.kernel.org/) fi
 - [x] Directory to erofs packing
 - [x] AUFS whiteout to overlayfs conversion
 - [x] Merge multiple filesystem layers with whiteout processing
-- [ ] Read erofs files with compression
+- [x] Read and write erofs files with LZ4 compression
 
 ## Reading an EROFS image
 

--- a/decompressor.go
+++ b/decompressor.go
@@ -92,11 +92,16 @@ func lz4UncompressPartial(dst, src []byte) (int, error) {
 		offset := int(src[si]) | int(src[si+1])<<8
 		si += 2
 		if offset == 0 {
-			// Zero offset is invalid in real LZ4 data and is what zero
-			// padding decodes to once the literal section is exhausted.
-			// Treat it as the end of meaningful output rather than a
-			// hard error so pclusters padded with zeros behave like the
-			// kernel's partial decoder.
+			// Offset 0 is invalid in real LZ4 data and is what trailing
+			// zero padding decodes to once we've stepped past the natural
+			// end of the LZ4 stream. Treat it as end-of-stream only if we
+			// have already produced the full requested output — otherwise
+			// it's a truncated stream that happens to have zero bytes
+			// where the offset field would be, and silently returning a
+			// short decode would mask real corruption.
+			if di < len(dst) {
+				return 0, fmt.Errorf("lz4: zero match offset before end of output (%d/%d bytes decoded)", di, len(dst))
+			}
 			return di, nil
 		}
 		if offset > di {

--- a/decompressor.go
+++ b/decompressor.go
@@ -1,0 +1,179 @@
+package erofs
+
+import (
+	"fmt"
+
+	"github.com/pierrec/lz4/v4"
+
+	"github.com/erofs/go-erofs/internal/disk"
+)
+
+// decompressor decompresses a single pcluster's worth of bytes.
+type decompressor interface {
+	// decompress reads up to len(dst) bytes of decompressed output from src
+	// into dst, returning the number of bytes written. src is the raw on-disk
+	// pcluster payload (already stripped of any leading 0-padding for LZ4).
+	decompress(dst, src []byte) (int, error)
+}
+
+type lz4Decompressor struct{}
+
+func (lz4Decompressor) decompress(dst, src []byte) (int, error) {
+	// EROFS pclusters zero-pad their LZ4 payload to a full physical block,
+	// so the trailing src bytes are not part of the LZ4 stream. The kernel
+	// uses LZ4_decompress_safe_partial which stops when dst is full and
+	// tolerates trailing input. pierrec/lz4 instead errors on leftover
+	// input, so we use an in-tree decoder modelled on the reference
+	// implementation.
+	n, err := lz4UncompressPartial(dst, src)
+	if err != nil {
+		return 0, fmt.Errorf("lz4 decompress: %w", err)
+	}
+	return n, nil
+}
+
+// lz4UncompressPartial decodes an LZ4 block into dst, stopping when dst is
+// full. It matches kernel `LZ4_decompress_safe_partial` semantics: trailing
+// bytes in src past the natural end of the LZ4 stream are ignored.
+func lz4UncompressPartial(dst, src []byte) (int, error) {
+	const minMatch = 4
+	var si, di int
+	for si < len(src) {
+		if di >= len(dst) {
+			return di, nil
+		}
+		token := int(src[si])
+		si++
+
+		// Literal length: high nibble, with 0xF prefix for extended length.
+		lLen := token >> 4
+		if lLen == 0xF {
+			for {
+				if si >= len(src) {
+					return 0, fmt.Errorf("lz4: truncated literal length")
+				}
+				x := int(src[si])
+				si++
+				lLen += x
+				if x != 0xFF {
+					break
+				}
+			}
+		}
+
+		if lLen > 0 {
+			if di+lLen > len(dst) {
+				// LZ4 partial: clip the trailing literal copy to dst.
+				lLen = len(dst) - di
+			}
+			if si+lLen > len(src) {
+				return 0, fmt.Errorf("lz4: truncated literal data")
+			}
+			copy(dst[di:di+lLen], src[si:si+lLen])
+			si += lLen
+			di += lLen
+		}
+
+		if di >= len(dst) {
+			return di, nil
+		}
+		// End-of-block: a clean LZ4 stream ends right after a literal
+		// sequence with mLen=0 — i.e. when si has reached the natural end
+		// of the encoder's output. Pclusters pad past this with zeros, so
+		// detect end-of-block by looking at the token's match nibble.
+		if si >= len(src) {
+			return di, nil
+		}
+
+		// 16-bit little-endian match offset.
+		if si+2 > len(src) {
+			return 0, fmt.Errorf("lz4: truncated match offset")
+		}
+		offset := int(src[si]) | int(src[si+1])<<8
+		si += 2
+		if offset == 0 {
+			// Zero offset is invalid in real LZ4 data and is what zero
+			// padding decodes to once the literal section is exhausted.
+			// Treat it as the end of meaningful output rather than a
+			// hard error so pclusters padded with zeros behave like the
+			// kernel's partial decoder.
+			return di, nil
+		}
+		if offset > di {
+			return 0, fmt.Errorf("lz4: match offset %d > written %d", offset, di)
+		}
+
+		mLen := token & 0xF
+		if mLen == 0xF {
+			for {
+				if si >= len(src) {
+					return 0, fmt.Errorf("lz4: truncated match length")
+				}
+				x := int(src[si])
+				si++
+				mLen += x
+				if x != 0xFF {
+					break
+				}
+			}
+		}
+		mLen += minMatch
+
+		for mLen > 0 {
+			n := offset
+			if n > mLen {
+				n = mLen
+			}
+			if di+n > len(dst) {
+				n = len(dst) - di
+			}
+			if n <= 0 {
+				return di, nil
+			}
+			copy(dst[di:di+n], dst[di-offset:di-offset+n])
+			di += n
+			mLen -= n
+		}
+	}
+	return di, nil
+}
+
+
+// pickDecompressor returns the decompressor for the given on-disk algorithm
+// identifier, or an error if the algorithm is unsupported.
+func pickDecompressor(algo uint8) (decompressor, error) {
+	switch algo {
+	case disk.ZErofsCompressionLZ4:
+		return lz4Decompressor{}, nil
+	}
+	return nil, fmt.Errorf("compression algorithm %d: %w", algo, ErrNotImplemented)
+}
+
+// compressor produces a compressed block of bytes. CompressBlock fills dst
+// with the LZ4-compressed encoding of src and returns the number of bytes
+// written. A return value of 0 indicates the input was incompressible (the
+// caller should emit the input uncompressed as a PLAIN lcluster).
+type compressor interface {
+	compressBlock(dst, src []byte) (int, error)
+}
+
+type lz4Compressor struct{}
+
+func (lz4Compressor) compressBlock(dst, src []byte) (int, error) {
+	var c lz4.Compressor
+	n, err := c.CompressBlock(src, dst)
+	if err != nil {
+		return 0, fmt.Errorf("lz4 compress: %w", err)
+	}
+	return n, nil
+}
+
+// pickCompressor returns a compressor for the given algorithm. Algorithm 0
+// (LZ4) is the only supported writer target.
+func pickCompressor(c Compression) (uint8, compressor, error) {
+	switch c {
+	case CompressionLZ4:
+		return disk.ZErofsCompressionLZ4, lz4Compressor{}, nil
+	}
+	return 0, nil, fmt.Errorf("compression %d: %w", c, ErrNotImplemented)
+}

--- a/decompressor.go
+++ b/decompressor.go
@@ -146,8 +146,7 @@ func lz4UncompressPartial(dst, src []byte) (int, error) {
 // pickDecompressor returns the decompressor for the given on-disk algorithm
 // identifier, or an error if the algorithm is unsupported.
 func pickDecompressor(algo uint8) (decompressor, error) {
-	switch algo {
-	case disk.ZErofsCompressionLZ4:
+	if algo == disk.ZErofsCompressionLZ4 {
 		return lz4Decompressor{}, nil
 	}
 	return nil, fmt.Errorf("compression algorithm %d: %w", algo, ErrNotImplemented)
@@ -160,8 +159,12 @@ func pickDecompressor(algo uint8) (decompressor, error) {
 // lcluster). Argument order is (src, dst), matching the underlying
 // pierrec/lz4 CompressBlock — both []byte, so the type system can't catch
 // a swap; the matching order at least makes the impl pass-through.
+//
+// algorithmID reports the on-disk Z_EROFS_COMPRESSION_* identifier recorded
+// in the z_erofs map header and the superblock's compression bitmap.
 type compressor interface {
 	compressBlock(src, dst []byte) (int, error)
+	algorithmID() uint8
 }
 
 type lz4Compressor struct{}
@@ -175,12 +178,13 @@ func (lz4Compressor) compressBlock(src, dst []byte) (int, error) {
 	return n, nil
 }
 
-// pickCompressor returns a compressor for the given algorithm. Algorithm 0
-// (LZ4) is the only supported writer target.
-func pickCompressor(c Compression) (uint8, compressor, error) {
-	switch c {
-	case CompressionLZ4:
-		return disk.ZErofsCompressionLZ4, lz4Compressor{}, nil
+func (lz4Compressor) algorithmID() uint8 { return disk.ZErofsCompressionLZ4 }
+
+// pickCompressor returns a compressor for the given algorithm. LZ4 is the
+// only supported writer target.
+func pickCompressor(c Compression) (compressor, error) {
+	if c == CompressionLZ4 {
+		return lz4Compressor{}, nil
 	}
-	return 0, nil, fmt.Errorf("compression %d: %w", c, ErrNotImplemented)
+	return nil, fmt.Errorf("compression %d: %w", c, ErrNotImplemented)
 }

--- a/decompressor.go
+++ b/decompressor.go
@@ -50,7 +50,7 @@ func lz4UncompressPartial(dst, src []byte) (int, error) {
 		if lLen == 0xF {
 			for {
 				if si >= len(src) {
-					return 0, fmt.Errorf("lz4: truncated literal length")
+					return 0, fmt.Errorf("lz4: truncated literal length: %w", ErrInvalid)
 				}
 				x := int(src[si])
 				si++
@@ -67,7 +67,7 @@ func lz4UncompressPartial(dst, src []byte) (int, error) {
 				lLen = len(dst) - di
 			}
 			if si+lLen > len(src) {
-				return 0, fmt.Errorf("lz4: truncated literal data")
+				return 0, fmt.Errorf("lz4: truncated literal data: %w", ErrInvalid)
 			}
 			copy(dst[di:di+lLen], src[si:si+lLen])
 			si += lLen
@@ -87,7 +87,7 @@ func lz4UncompressPartial(dst, src []byte) (int, error) {
 
 		// 16-bit little-endian match offset.
 		if si+2 > len(src) {
-			return 0, fmt.Errorf("lz4: truncated match offset")
+			return 0, fmt.Errorf("lz4: truncated match offset: %w", ErrInvalid)
 		}
 		offset := int(src[si]) | int(src[si+1])<<8
 		si += 2
@@ -100,19 +100,19 @@ func lz4UncompressPartial(dst, src []byte) (int, error) {
 			// where the offset field would be, and silently returning a
 			// short decode would mask real corruption.
 			if di < len(dst) {
-				return 0, fmt.Errorf("lz4: zero match offset before end of output (%d/%d bytes decoded)", di, len(dst))
+				return 0, fmt.Errorf("lz4: zero match offset before end of output (%d/%d bytes decoded): %w", di, len(dst), ErrInvalid)
 			}
 			return di, nil
 		}
 		if offset > di {
-			return 0, fmt.Errorf("lz4: match offset %d > written %d", offset, di)
+			return 0, fmt.Errorf("lz4: match offset %d > written %d: %w", offset, di, ErrInvalid)
 		}
 
 		mLen := token & 0xF
 		if mLen == 0xF {
 			for {
 				if si >= len(src) {
-					return 0, fmt.Errorf("lz4: truncated match length")
+					return 0, fmt.Errorf("lz4: truncated match length: %w", ErrInvalid)
 				}
 				x := int(src[si])
 				si++

--- a/decompressor.go
+++ b/decompressor.go
@@ -143,7 +143,6 @@ func lz4UncompressPartial(dst, src []byte) (int, error) {
 	return di, nil
 }
 
-
 // pickDecompressor returns the decompressor for the given on-disk algorithm
 // identifier, or an error if the algorithm is unsupported.
 func pickDecompressor(algo uint8) (decompressor, error) {

--- a/decompressor.go
+++ b/decompressor.go
@@ -154,17 +154,20 @@ func pickDecompressor(algo uint8) (decompressor, error) {
 	return nil, fmt.Errorf("compression algorithm %d: %w", algo, ErrNotImplemented)
 }
 
-// compressor produces a compressed block of bytes. CompressBlock fills dst
-// with the LZ4-compressed encoding of src and returns the number of bytes
-// written. A return value of 0 indicates the input was incompressible (the
-// caller should emit the input uncompressed as a PLAIN lcluster).
+// compressor produces a compressed block of bytes. compressBlock reads from
+// src and writes the LZ4-compressed encoding into dst, returning the number
+// of bytes written. A return value of 0 indicates the input was
+// incompressible (the caller should emit the input uncompressed as a PLAIN
+// lcluster). Argument order is (src, dst), matching the underlying
+// pierrec/lz4 CompressBlock — both []byte, so the type system can't catch
+// a swap; the matching order at least makes the impl pass-through.
 type compressor interface {
-	compressBlock(dst, src []byte) (int, error)
+	compressBlock(src, dst []byte) (int, error)
 }
 
 type lz4Compressor struct{}
 
-func (lz4Compressor) compressBlock(dst, src []byte) (int, error) {
+func (lz4Compressor) compressBlock(src, dst []byte) (int, error) {
 	var c lz4.Compressor
 	n, err := c.CompressBlock(src, dst)
 	if err != nil {

--- a/decompressor_fuzz_test.go
+++ b/decompressor_fuzz_test.go
@@ -1,0 +1,51 @@
+package erofs
+
+import (
+	"testing"
+)
+
+// FuzzLz4UncompressPartial drives lz4UncompressPartial with arbitrary src
+// bytes and dst sizes. The decoder is on the read path for every compressed
+// EROFS image, so it must not panic, infinite-loop, or write past the
+// caller-provided destination buffer for any attacker-controlled input.
+//
+// The invariants checked are intentionally weak — fuzzing isn't trying to
+// catch decoded-output mismatches (we have round-trip tests for that), just
+// that the function returns within reasonable bounds without crashing.
+func FuzzLz4UncompressPartial(f *testing.F) {
+	// Seed with a few hand-crafted cases that exercise distinct branches
+	// in the decoder: empty, literal-only, all-zero (offset==0 path),
+	// token-with-extended-length, etc. The fuzzer will mutate from here.
+	f.Add([]byte{}, uint16(0))
+	f.Add([]byte{}, uint16(4096))
+	f.Add([]byte{0x00, 0x00, 0x00}, uint16(16))                                       // token 0x00 + zeros (offset==0 path)
+	f.Add([]byte{0x10, 0xAA}, uint16(16))                                             // 1-byte literal
+	f.Add([]byte{0x50, 'h', 'e', 'l', 'l', 'o', 0x05, 0x00}, uint16(32))              // literal + match
+	f.Add([]byte{0xF0, 0x00, 0xAA}, uint16(16))                                       // extended literal length=15
+	f.Add([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, uint16(8192)) // extension runaway
+
+	f.Fuzz(func(t *testing.T, src []byte, dstSize uint16) {
+		// Cap dst to a sane size so the fuzzer doesn't burn time on huge
+		// allocations; 64 KiB covers everything our reader will request
+		// (max blockSize * max pcluster lclusters).
+		const maxDst = 64 * 1024
+		size := int(dstSize)
+		if size > maxDst {
+			size = maxDst
+		}
+		dst := make([]byte, size)
+
+		n, err := lz4UncompressPartial(dst, src)
+
+		// Contract: on error n must be 0; on success 0 <= n <= len(dst).
+		if err != nil {
+			if n != 0 {
+				t.Errorf("error path returned n=%d (expected 0): %v", n, err)
+			}
+			return
+		}
+		if n < 0 || n > len(dst) {
+			t.Errorf("n=%d out of range [0, %d]", n, len(dst))
+		}
+	})
+}

--- a/erofs.go
+++ b/erofs.go
@@ -225,11 +225,14 @@ func Open(r io.ReaderAt, opts ...OpenOpt) (fs.FS, error) {
 		}
 	}
 
-	// Error out filesystems with unsupported compressed inodes
-	if i.sb.FeatureIncompat&disk.FeatureIncompatLZ4_0Padding != 0 ||
-		i.sb.ComprAlgs != 0 {
-		return nil, fmt.Errorf("unsupported compressed filesystem (FeatureIncompat=0x%x, ComprAlgs=0x%x): %w",
-			i.sb.FeatureIncompat, i.sb.ComprAlgs, ErrNotImplemented)
+	// Reject compression algorithms we don't yet implement. LZ4 is the only
+	// supported algorithm; LZMA/Deflate/Zstd images error out here. The
+	// LZ4_0Padding feature flag is a hint about the on-disk layout (the
+	// encoder may insert leading zero bytes in a pcluster) and is accepted
+	// unconditionally.
+	const supportedAlgs = uint16(1 << disk.ZErofsCompressionLZ4)
+	if unsupported := i.sb.ComprAlgs &^ supportedAlgs; unsupported != 0 {
+		return nil, fmt.Errorf("unsupported compression algorithms 0x%x: %w", unsupported, ErrNotImplemented)
 	}
 
 	i.blkPool.New = func() any {
@@ -702,7 +705,14 @@ func (img *image) loadBlock(fi *inode, pos int64) (*block, error) {
 		b.end = int32(blockEnd)
 		return b, nil
 	case disk.LayoutCompressedFull, disk.LayoutCompressedCompact:
-		return nil, fmt.Errorf("inode layout (%d) for %d: %w", fi.inodeLayout, fi.nid, ErrNotImplemented)
+		data, err := img.readCompressed(fi, pos)
+		if err != nil {
+			return nil, err
+		}
+		b := img.getBlock()
+		b.offset = 0
+		b.end = int32(copy(b.buf, data))
+		return b, nil
 	default:
 		return nil, fmt.Errorf("inode layout (%d) for %d: %w", fi.inodeLayout, fi.nid, ErrInvalid)
 	}
@@ -1619,6 +1629,7 @@ type inode struct {
 	mtime       uint64
 	mtimeNs     uint32
 	cached      *block
+	zmap        *zmapState // lazily populated for compressed inodes
 }
 
 func (ino *inode) flatDataOffset() int64 {

--- a/erofs.go
+++ b/erofs.go
@@ -230,9 +230,16 @@ func Open(r io.ReaderAt, opts ...OpenOpt) (fs.FS, error) {
 	// LZ4_0Padding feature flag is a hint about the on-disk layout (the
 	// encoder may insert leading zero bytes in a pcluster) and is accepted
 	// unconditionally.
-	const supportedAlgs = uint16(1 << disk.ZErofsCompressionLZ4)
-	if unsupported := i.sb.ComprAlgs &^ supportedAlgs; unsupported != 0 {
-		return nil, fmt.Errorf("unsupported compression algorithms 0x%x: %w", unsupported, ErrNotImplemented)
+	//
+	// ComprAlgs is the same struct field as lz4_max_distance: it's a bitmap
+	// of available algorithms only when FEATURE_INCOMPAT_COMPR_CFGS is set;
+	// otherwise it carries the LZ4 max sliding distance and any bit pattern
+	// is legal.
+	if i.sb.FeatureIncompat&disk.FeatureIncompatComprCfgs != 0 {
+		const supportedAlgs = uint16(1 << disk.ZErofsCompressionLZ4)
+		if unsupported := i.sb.ComprAlgs &^ supportedAlgs; unsupported != 0 {
+			return nil, fmt.Errorf("unsupported compression algorithms 0x%x: %w", unsupported, ErrNotImplemented)
+		}
 	}
 
 	i.blkPool.New = func() any {

--- a/erofs_test.go
+++ b/erofs_test.go
@@ -64,14 +64,15 @@ func TestErofs(t *testing.T) {
 		erofstest.SparseFiles.Run(t, erofstest.MkfsErofsMaxSize(1024*1024, chunkFlag))
 	})
 
-	// Compression format is unimplemented — verify EroFS returns ErrNotImplemented.
-	t.Run("lz4-unimplemented", func(t *testing.T) {
+	// Compressed images produced by stock mkfs.erofs -zlz4 must round-trip.
+	t.Run("lz4-mkfs-roundtrip", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("mkfs.erofs compression is not included on Windows")
 		}
+		const content = "this is the file content that will be compressed by lz4\n"
 		tc := erofstest.TarContext{}
 		wt := erofstest.TarAll(
-			tc.File("/file.txt", []byte("content\n"), 0644),
+			tc.File("/file.txt", []byte(content), 0644),
 		)
 		tarStream := erofstest.TarFromWriterTo(wt)
 		defer func() {
@@ -95,10 +96,11 @@ func TestErofs(t *testing.T) {
 			}
 		}()
 
-		_, err = erofs.Open(f)
-		if !errors.Is(err, erofs.ErrNotImplemented) {
-			t.Fatalf("expected ErrNotImplemented, got %v", err)
+		efs, err := erofs.Open(f)
+		if err != nil {
+			t.Fatal("Open compressed image:", err)
 		}
+		erofstest.CheckFile(t, efs, "file.txt", content)
 	})
 }
 

--- a/erofs_test.go
+++ b/erofs_test.go
@@ -65,14 +65,27 @@ func TestErofs(t *testing.T) {
 	})
 
 	// Compressed images produced by stock mkfs.erofs -zlz4 must round-trip.
+	// Covers both the trivial single-block file and a multi-block compressible
+	// file whose lcluster index actually exercises the compact-mode pblk
+	// walkback loop and (for big enough inputs) the compacted_2b run.
 	t.Run("lz4-mkfs-roundtrip", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("mkfs.erofs compression is not included on Windows")
 		}
-		const content = "this is the file content that will be compressed by lz4\n"
+		const single = "this is the file content that will be compressed by lz4\n"
+		// ~256 KiB of highly compressible repeating data — large enough that
+		// at 4 KiB blocks the compact index needs many lclusters, and the
+		// COMPACTED_2B advise bit gets set on the trailing pack(s).
+		bigPattern := bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog\n"), 6000)
+		// Mixed content: a file with a partial tail to exercise tail clamping
+		// through the compact decoder.
+		tailed := append(bytes.Repeat([]byte("ABCDEFGHIJKLMNOP"), 4096), []byte("tail bytes\n")...)
+
 		tc := erofstest.TarContext{}
 		wt := erofstest.TarAll(
-			tc.File("/file.txt", []byte(content), 0644),
+			tc.File("/file.txt", []byte(single), 0644),
+			tc.File("/big.txt", bigPattern, 0644),
+			tc.File("/tailed.bin", tailed, 0644),
 		)
 		tarStream := erofstest.TarFromWriterTo(wt)
 		defer func() {
@@ -100,7 +113,9 @@ func TestErofs(t *testing.T) {
 		if err != nil {
 			t.Fatal("Open compressed image:", err)
 		}
-		erofstest.CheckFile(t, efs, "file.txt", content)
+		erofstest.CheckFile(t, efs, "file.txt", single)
+		erofstest.CheckFileBytes(t, efs, "big.txt", bigPattern)
+		erofstest.CheckFileBytes(t, efs, "tailed.bin", tailed)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/erofs/go-erofs
 
 go 1.23
+
+require github.com/pierrec/lz4/v4 v4.1.26

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
+github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=

--- a/internal/disk/types.go
+++ b/internal/disk/types.go
@@ -64,6 +64,14 @@ const (
 
 	SizeZErofsMapHeader     = 8
 	SizeZErofsLclusterIndex = 8
+
+	// MaxPclusterSize is the upper bound on a single pcluster's on-disk
+	// size in bytes, matching the kernel's Z_EROFS_PCLUSTER_MAX_SIZE
+	// (fs/erofs/erofs_fs.h). Used to bound buffer allocations on the read
+	// path so a corrupted (or malicious) lcluster index can't drive a
+	// huge allocation. 1 MiB is the kernel's absolute cap regardless of
+	// block size.
+	MaxPclusterSize = 1024 * 1024
 )
 
 // SuperBlock represents the EROFS on-disk superblock.

--- a/internal/disk/types.go
+++ b/internal/disk/types.go
@@ -31,6 +31,39 @@ const (
 	LayoutChunkFormatBits    = 0x001F
 	LayoutChunkFormatIndexes = 0x0020
 	LayoutChunkFormat48Bit   = 0x0040
+
+	// Compression algorithm identifiers stored in ZErofsMapHeader.AlgorithmType
+	// and indexed as bit positions in SuperBlock.ComprAlgs.
+	ZErofsCompressionLZ4     = 0
+	ZErofsCompressionLZMA    = 1
+	ZErofsCompressionDeflate = 2
+	ZErofsCompressionZstd    = 3
+	ZErofsCompressionMax     = 4
+
+	// Bit flags in ZErofsMapHeader.HAdvise.
+	ZErofsAdviseCompacted2B        = 0x0001
+	ZErofsAdviseBigPcluster1       = 0x0002
+	ZErofsAdviseBigPcluster2       = 0x0004
+	ZErofsAdviseInlinePcluster     = 0x0008
+	ZErofsAdviseInterlacedPcluster = 0x0010
+	ZErofsAdviseFragmentPcluster   = 0x0020
+
+	// Logical cluster types in the low 2 bits of ZErofsLclusterIndex.DiAdvise.
+	ZErofsLclusterTypePlain   = 0
+	ZErofsLclusterTypeHead1   = 1
+	ZErofsLclusterTypeNonhead = 2
+	ZErofsLclusterTypeHead2   = 3
+	ZErofsLclusterTypeMask    = 0x3
+
+	// Additional flags packed into ZErofsLclusterIndex.DiAdvise above the
+	// 2-bit type. PartialRef marks the trailing lcluster of a partial-ref
+	// pcluster; D0CblkCnt marks a NONHEAD whose di_u carries the block count
+	// of the preceding pcluster instead of a delta.
+	ZErofsLiPartialRef = 1 << 15
+	ZErofsLiD0CblkCnt  = 1 << 11
+
+	SizeZErofsMapHeader     = 8
+	SizeZErofsLclusterIndex = 8
 )
 
 // SuperBlock represents the EROFS on-disk superblock.
@@ -143,6 +176,32 @@ type InodeChunkIndex struct {
 	StartBlkHi uint16 // part of 48-bit support (not yet implemented)
 	DeviceID   uint16
 	StartBlkLo uint32
+}
+
+// ZErofsMapHeader is the 8-byte z_erofs_map_header that immediately follows
+// the inode core + xattr area for compressed inodes and precedes the
+// lcluster index table.
+//
+// On disk the first 4 bytes are a union of h_fragmentoff (for fragment
+// inodes), h_reserved1+h_idata_size (for inline-pcluster inodes), and
+// h_extents_lo. The remaining 4 bytes hold h_advise plus either
+// h_algorithmtype+h_clusterbits or h_extents_hi.
+type ZErofsMapHeader struct {
+	FragmentOff   uint32 // overloaded with h_idata_size in high 16 bits
+	HAdvise       uint16
+	AlgorithmType uint8 // overloaded as low byte of h_extents_hi
+	ClusterBits   uint8 // overloaded as high byte of h_extents_hi
+}
+
+// ZErofsLclusterIndex is one full-format (8-byte) logical cluster index entry.
+// The low ZErofsLclusterTypeMask bits of DiAdvise select the cluster type.
+// For HEAD1/HEAD2/PLAIN clusters DiU is a block address; for NONHEAD it is
+// two little-endian uint16 deltas (delta[0]=distance back to head pcluster,
+// delta[1]=distance forward to the next head).
+type ZErofsLclusterIndex struct {
+	DiAdvise     uint16
+	DiClusterOfs uint16
+	DiU          uint32
 }
 
 // DeviceSlot represents the on-disk device table entry (erofs_deviceslot).

--- a/internal/disk/types.go
+++ b/internal/disk/types.go
@@ -5,13 +5,19 @@ const (
 	SuperBlockOffset = 1024
 
 	FeatureIncompatLZ4_0Padding         = 0x1
+	// FeatureIncompatComprCfgs covers both the per-algorithm compression
+	// configuration area (placed right after the superblock) and the
+	// "big pcluster" capability — the kernel uses 0x02 for both.
+	FeatureIncompatComprCfgs            = 0x2
+	FeatureIncompatBigPcluster          = 0x2
 	FeatureIncompatChunkedFile          = 0x4
 	FeatureIncompatDeviceTable          = 0x8
 	FeatureIncompatFragments            = 0x20
 	FeatureIncompatXattrPrefixes        = 0x40
 	FeatureIncompatAll           uint32 = FeatureIncompatLZ4_0Padding |
-		FeatureIncompatChunkedFile | FeatureIncompatDeviceTable |
-		FeatureIncompatFragments | FeatureIncompatXattrPrefixes
+		FeatureIncompatComprCfgs | FeatureIncompatChunkedFile |
+		FeatureIncompatDeviceTable | FeatureIncompatFragments |
+		FeatureIncompatXattrPrefixes
 
 	SizeSuperBlock      = 128
 	SizeInodeCompact    = 32
@@ -64,6 +70,7 @@ const (
 
 	SizeZErofsMapHeader     = 8
 	SizeZErofsLclusterIndex = 8
+	SizeZErofsLZ4Cfgs       = 14 // struct z_erofs_lz4_cfgs (excludes 2-byte length prefix)
 
 	// MaxPclusterSize is the upper bound on a single pcluster's on-disk
 	// size in bytes, matching the kernel's Z_EROFS_PCLUSTER_MAX_SIZE

--- a/internal/disk/types.go
+++ b/internal/disk/types.go
@@ -4,7 +4,7 @@ const (
 	MagicNumber      = 0xe0f5e1e2
 	SuperBlockOffset = 1024
 
-	FeatureIncompatLZ4_0Padding         = 0x1
+	FeatureIncompatLZ4_0Padding = 0x1
 	// FeatureIncompatComprCfgs covers both the per-algorithm compression
 	// configuration area (placed right after the superblock) and the
 	// "big pcluster" capability — the kernel uses 0x02 for both.

--- a/kernelmount_test.go
+++ b/kernelmount_test.go
@@ -42,9 +42,9 @@ func TestKernelMountCompressed(t *testing.T) {
 	// inline-eligible, big-pcluster compressible, partial-tail compressible,
 	// incompressible (forces PLAIN fallback).
 	files := map[string][]byte{
-		"/tiny.txt":      []byte("hi\n"),
-		"/compressible":  bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog\n"), 1500),
-		"/partial-tail":  append(bytes.Repeat([]byte("ABCDEFGHIJKLMNOP"), 4096), []byte("trailer\n")...),
+		"/tiny.txt":     []byte("hi\n"),
+		"/compressible": bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog\n"), 1500),
+		"/partial-tail": append(bytes.Repeat([]byte("ABCDEFGHIJKLMNOP"), 4096), []byte("trailer\n")...),
 		"/incompressible": func() []byte {
 			b := make([]byte, 32*1024)
 			for i := range b {

--- a/kernelmount_test.go
+++ b/kernelmount_test.go
@@ -1,0 +1,123 @@
+package erofs_test
+
+import (
+	"bytes"
+	"crypto/md5"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	erofs "github.com/erofs/go-erofs"
+)
+
+// TestKernelMountCompressed builds a compressed (big-pcluster) image with
+// the writer, asks the running kernel to mount it via loopback, and verifies
+// every file reads back byte-identical. It exercises the on-disk encoding
+// against a real kernel driver — something the rest of the Go test suite
+// can't do, since it only round-trips through this library's own reader.
+//
+// Off by default because it requires:
+//   - Linux (the only OS with an EROFS driver),
+//   - root or passwordless sudo for mount/umount,
+//   - the erofs module to be available on the running kernel.
+//
+// Opt in with:
+//
+//	EROFS_KERNEL_TESTS=1 go test -run TestKernelMountCompressed ./...
+//
+// Would have caught the FEATURE_INCOMPAT_BIG_PCLUSTER omission that
+// previously shipped only to be fixed in a follow-up commit.
+func TestKernelMountCompressed(t *testing.T) {
+	if os.Getenv("EROFS_KERNEL_TESTS") == "" {
+		t.Skip("set EROFS_KERNEL_TESTS=1 to enable; requires Linux + sudo")
+	}
+	if runtime.GOOS != "linux" {
+		t.Skip("kernel mount tests only run on Linux")
+	}
+
+	// Build an image with content spanning the writer's interesting paths:
+	// inline-eligible, big-pcluster compressible, partial-tail compressible,
+	// incompressible (forces PLAIN fallback).
+	files := map[string][]byte{
+		"/tiny.txt":      []byte("hi\n"),
+		"/compressible":  bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog\n"), 1500),
+		"/partial-tail":  append(bytes.Repeat([]byte("ABCDEFGHIJKLMNOP"), 4096), []byte("trailer\n")...),
+		"/incompressible": func() []byte {
+			b := make([]byte, 32*1024)
+			for i := range b {
+				b[i] = byte(i*1103515245 + 12345)
+			}
+			return b
+		}(),
+	}
+
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "test.erofs")
+	out, err := os.Create(imgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := erofs.Create(out, erofs.WithCompression(erofs.CompressionLZ4))
+	for path, data := range files {
+		f, err := w.Create(path)
+		if err != nil {
+			t.Fatalf("Create %s: %v", path, err)
+		}
+		if _, err := f.Write(data); err != nil {
+			t.Fatalf("Write %s: %v", path, err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("Close %s: %v", path, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal("Writer.Close:", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mount via the kernel driver. sudo -n fails fast when passwordless
+	// sudo isn't configured; skip the test rather than hang prompting.
+	mp := filepath.Join(dir, "mnt")
+	if err := os.Mkdir(mp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mountCmd := exec.Command("sudo", "-n", "mount", "-t", "erofs", "-o", "loop", imgPath, mp)
+	if mountOut, err := mountCmd.CombinedOutput(); err != nil {
+		t.Skipf("kernel mount failed (sudo / loop / erofs module not available?): %v\n%s", err, mountOut)
+	}
+	t.Cleanup(func() {
+		if out, err := exec.Command("sudo", "-n", "umount", mp).CombinedOutput(); err != nil {
+			t.Logf("umount failed: %v\n%s", err, out)
+		}
+	})
+
+	// Verify every file reads back byte-identical.
+	for path, want := range files {
+		got, err := os.ReadFile(filepath.Join(mp, path))
+		if err != nil {
+			t.Errorf("read %s: %v", path, err)
+			continue
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("%s: content mismatch (got md5=%x, want md5=%x; %d vs %d bytes)",
+				path, md5.Sum(got), md5.Sum(want), len(got), len(want))
+		}
+	}
+
+	t.Logf("verified %d files via kernel mount of %s",
+		len(files), fmt.Sprintf("%s (%d bytes)", imgPath, fileSize(t, imgPath)))
+}
+
+func fileSize(t *testing.T, p string) int64 {
+	t.Helper()
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fi.Size()
+}

--- a/layout.go
+++ b/layout.go
@@ -76,15 +76,19 @@ func (w *erofsWriter) planLayout(root *erofsEntry) {
 					e.chunkBits = w.minChunkBits(e.size)
 				}
 			default:
-				// Full-image mode: decide inline vs plain
-				if int(e.size) <= w.blockSize-headerSize {
-					inBlockOff := (currentOff + headerSize) % w.blockSize
-					if inBlockOff+int(e.size) <= w.blockSize {
-						e.layout = disk.LayoutFlatInline
-					} else {
-						e.layout = disk.LayoutFlatPlain
-					}
-				} else {
+				// Full-image mode: decide inline vs compressed vs plain.
+				// Inline is preferred for files that fit entirely after the
+				// inode core+xattrs because it saves a whole data block.
+				inBlockOff := (currentOff + headerSize) % w.blockSize
+				canInline := int(e.size) <= w.blockSize-headerSize &&
+					inBlockOff+int(e.size) <= w.blockSize
+				switch {
+				case canInline:
+					e.layout = disk.LayoutFlatInline
+				case w.compression != CompressionNone:
+					e.layout = disk.LayoutCompressedFull
+					e.nLclusters = uint32((e.size + uint64(w.blockSize) - 1) / uint64(w.blockSize))
+				default:
 					e.layout = disk.LayoutFlatPlain
 				}
 			}
@@ -188,6 +192,22 @@ func (w *erofsWriter) calcTrailingSize(e *erofsEntry) int {
 		}
 		if e.layout == disk.LayoutFlatInline {
 			return int(e.size)
+		}
+		if e.layout == disk.LayoutCompressedFull {
+			// COMPRESSED_FULL trailing area:
+			//   alignPad zero bytes so the map header starts at an 8-byte
+			//   boundary within the metadata zone (Z_EROFS_MAP_HEADER_START
+			//   uses round_up(end, 8)),
+			//   8 bytes z_erofs_map_header,
+			//   8 bytes reserved (Z_EROFS_FULL_INDEX_START gap),
+			//   nLclusters * 8 bytes lcluster index entries.
+			//
+			// Inode core size is always a multiple of 8 (32 or 64). xattr
+			// entries are 4-aligned, so alignPad is 0 or 4.
+			headerSize := inodeCoreSize(e) + e.xattrSize
+			alignPad := (8 - (headerSize % 8)) % 8
+			return alignPad + disk.SizeZErofsMapHeader + 8 +
+				int(e.nLclusters)*disk.SizeZErofsLclusterIndex
 		}
 		return 0
 	case disk.StatTypeDir:

--- a/mkfs.go
+++ b/mkfs.go
@@ -659,6 +659,7 @@ func (fsys *Writer) Close() error {
 		chunkBits:   chunkBits,
 		zeroBuf:     make([]byte, fsys.blockSize),
 		compression: fsys.compression,
+		tempDir:     fsys.tempDir,
 	}
 
 	ew.planLayout(root)
@@ -1087,15 +1088,15 @@ type erofsEntry struct {
 	dataBlkAddr uint32
 
 	// Compressed regular file state. nLclusters is set during planLayout.
-	// compressEntry is called between planLayout and write: it fills
-	// compressedData (the on-disk pcluster bytes, exactly nPblks blocks),
-	// lclusterEntries (one entry per lcluster), and nPblks (the actual
-	// physical block count, which may be less than nLclusters when
-	// big-pcluster grouping wins).
+	// compressEntry is called between planLayout and write: it appends the
+	// on-disk pcluster bytes (exactly nPblks blocks) to the writer's shared
+	// cspool starting at cspoolOff, fills lclusterEntries (one entry per
+	// lcluster) and sets nPblks (the actual physical block count, which
+	// may be less than nLclusters when big-pcluster grouping wins).
 	nLclusters      uint32
 	nPblks          uint32
+	cspoolOff       int64
 	lclusterEntries []lclusterEntry
-	compressedData  []byte
 }
 
 // lclusterEntry captures the on-disk z_erofs_lcluster_index entry for one

--- a/mkfs.go
+++ b/mkfs.go
@@ -1091,12 +1091,16 @@ type erofsEntry struct {
 	// compressEntry is called between planLayout and write: it appends the
 	// on-disk pcluster bytes (exactly nPblks blocks) to the writer's shared
 	// cspool starting at cspoolOff, fills lclusterEntries (one entry per
-	// lcluster) and sets nPblks (the actual physical block count, which
+	// lcluster), and sets nPblks (the actual physical block count, which
 	// may be less than nLclusters when big-pcluster grouping wins).
+	// hasBigPcluster is set when at least one CBLKCNT NONHEAD was emitted —
+	// readers in writeBlock0 / writeCompressedTrailing consult it without
+	// re-scanning lclusterEntries.
 	nLclusters      uint32
 	nPblks          uint32
 	cspoolOff       int64
 	lclusterEntries []lclusterEntry
+	hasBigPcluster  bool
 }
 
 // lclusterEntry captures the on-disk z_erofs_lcluster_index entry for one

--- a/mkfs.go
+++ b/mkfs.go
@@ -662,6 +662,9 @@ func (fsys *Writer) Close() error {
 	}
 
 	ew.planLayout(root)
+	if err := ew.compressEntries(); err != nil {
+		return err
+	}
 	fixParentNids(root, root)
 
 	return ew.write(fsys.out)
@@ -1083,11 +1086,25 @@ type erofsEntry struct {
 	// Data block address for flat-plain files (full-image mode)
 	dataBlkAddr uint32
 
-	// Compressed regular file state. nLclusters is set during planLayout;
-	// lclusterTypes is filled during writeDataBlocks and consumed by
-	// writeCompressedTrailing.
-	nLclusters    uint32
-	lclusterTypes []uint8 // per-lcluster: Z_EROFS_LCLUSTER_TYPE_HEAD1 or _PLAIN
+	// Compressed regular file state. nLclusters is set during planLayout.
+	// compressEntry is called between planLayout and write: it fills
+	// compressedData (the on-disk pcluster bytes, exactly nPblks blocks),
+	// lclusterEntries (one entry per lcluster), and nPblks (the actual
+	// physical block count, which may be less than nLclusters when
+	// big-pcluster grouping wins).
+	nLclusters      uint32
+	nPblks          uint32
+	lclusterEntries []lclusterEntry
+	compressedData  []byte
+}
+
+// lclusterEntry captures the on-disk z_erofs_lcluster_index entry for one
+// logical cluster of a LayoutCompressedFull regular file.
+type lclusterEntry struct {
+	typ    uint8  // disk.ZErofsLclusterType{Plain,Head1,Nonhead}
+	pblk   uint32 // physical block address (for HEAD1 / PLAIN)
+	delta0 uint16 // lookback distance to HEAD, or (M | D0_CBLKCNT) for big-pcluster
+	delta1 uint16 // lookahead distance to the next HEAD
 }
 
 // --- Internal helpers ---

--- a/mkfs.go
+++ b/mkfs.go
@@ -28,6 +28,7 @@ type Writer struct {
 	buildTime    uint64 // from WithBuildTime or buildTimer
 	buildTimeNs  uint32
 	hasBuildTime bool
+	compression  Compression
 	wErr         error               // sticky error: once set, all subsequent ops return it
 	root         *fsEntry            // root directory
 	byPath       map[string]*fsEntry // path → entry (all types)
@@ -83,6 +84,7 @@ func Create(out io.WriteSeeker, opts ...CreateOpt) *Writer {
 		buildTime:    o.buildTime,
 		buildTimeNs:  o.buildTimeNs,
 		hasBuildTime: o.hasBuildTime,
+		compression:  o.compression,
 		root:         root,
 		byPath:       map[string]*fsEntry{"/": root},
 		dataFile:     o.dataFile,
@@ -144,6 +146,36 @@ func Merge() CopyOpt {
 func WithBlockSize(n int) CreateOpt {
 	return func(o *createOptions) {
 		o.blockSize = n
+	}
+}
+
+// Compression selects an EROFS compression algorithm. Zero value means
+// no compression.
+type Compression uint8
+
+const (
+	// CompressionNone disables compression; regular files use flat layouts.
+	CompressionNone Compression = 0
+	// CompressionLZ4 enables LZ4 compression for regular files. Each
+	// blockSize-sized chunk of source data is compressed independently;
+	// chunks that don't compress smaller are stored uncompressed (PLAIN
+	// lcluster). Produces images readable by stock mkfs.erofs / kernel
+	// erofs drivers.
+	CompressionLZ4 Compression = 1
+)
+
+// WithCompression enables compression for regular files in the produced
+// image. When enabled, files large enough to benefit are written with the
+// EROFS COMPRESSED_FULL layout; files small enough for inline storage
+// keep the inline layout.
+//
+// Note: the current implementation uses single-block logical clusters and
+// does not pack multiple lclusters into a shared pcluster (the EROFS
+// "big-pcluster" feature). Output is a valid compressed image readable by
+// stock mkfs.erofs / kernel erofs, but disk-space savings are limited.
+func WithCompression(c Compression) CreateOpt {
+	return func(o *createOptions) {
+		o.compression = c
 	}
 }
 
@@ -626,6 +658,7 @@ func (fsys *Writer) Close() error {
 		blockSize:   fsys.blockSize,
 		chunkBits:   chunkBits,
 		zeroBuf:     make([]byte, fsys.blockSize),
+		compression: fsys.compression,
 	}
 
 	ew.planLayout(root)
@@ -960,6 +993,7 @@ type createOptions struct {
 	blockSize    int      // 0 = use default
 	dataFile     *os.File // external data file for metadata-only mode
 	tempDir      string   // temp directory for spool file
+	compression  Compression
 }
 
 // blockSizer may be implemented by an fs.FS to declare its block size.
@@ -1048,6 +1082,12 @@ type erofsEntry struct {
 
 	// Data block address for flat-plain files (full-image mode)
 	dataBlkAddr uint32
+
+	// Compressed regular file state. nLclusters is set during planLayout;
+	// lclusterTypes is filled during writeDataBlocks and consumed by
+	// writeCompressedTrailing.
+	nLclusters    uint32
+	lclusterTypes []uint8 // per-lcluster: Z_EROFS_LCLUSTER_TYPE_HEAD1 or _PLAIN
 }
 
 // --- Internal helpers ---

--- a/mkfs_test.go
+++ b/mkfs_test.go
@@ -3705,3 +3705,71 @@ func TestCopyFromHardlinkRequiresSameDev(t *testing.T) {
 		t.Errorf("a ino %d == b ino %d: same Ino but different Dev must not be coalesced", aSt.Ino, bSt.Ino)
 	}
 }
+
+// TestCreateFSCompressionLZ4 round-trips files through the LZ4 writer and
+// reader. It exercises three classes of regular file:
+//   - small file that still uses inline layout (compression is skipped),
+//   - highly compressible large file (HEAD1 lclusters),
+//   - incompressible large file (PLAIN lclusters via the writer's fallback).
+//
+// Self-contained: does not require mkfs.erofs / fsck.erofs.
+func TestCreateFSCompressionLZ4(t *testing.T) {
+	const blockSize = 4096
+
+	tiny := []byte("inline-me\n")
+	// 5 blocks worth of highly compressible repeating data.
+	compressible := bytes.Repeat([]byte("ABCDEFGHIJKLMNOP"), 5*blockSize/16)
+	// 2 blocks of random-ish data that won't fit when compressed; the
+	// writer should fall back to PLAIN lclusters and still round-trip.
+	incompressible := make([]byte, 2*blockSize)
+	for i := range incompressible {
+		// Use the low byte of a multiplier to spread values; avoid Go's
+		// math/rand to keep the test deterministic without seeding.
+		incompressible[i] = byte(i*1103515245 + 12345)
+	}
+	// 1 block exact + 13 bytes — exercises the partial tail lcluster.
+	tailed := append(bytes.Repeat([]byte("hello compression world\n"), blockSize/24), []byte("trailing bytes")...)
+
+	// Multi-block (10 blocks exact) compressible file — exercises many
+	// sequential lcluster decodes with cache reuse and no tail clamp.
+	bigCompressible := bytes.Repeat([]byte("0123456789ABCDEF"), 10*blockSize/16)
+
+	var buf testBuffer
+	w := erofs.Create(&buf, erofs.WithCompression(erofs.CompressionLZ4))
+
+	for _, c := range []struct {
+		path string
+		data []byte
+	}{
+		{"/tiny.txt", tiny},
+		{"/compressible.bin", compressible},
+		{"/incompressible.bin", incompressible},
+		{"/tailed.bin", tailed},
+		{"/big-compressible.bin", bigCompressible},
+	} {
+		f, err := w.Create(c.path)
+		if err != nil {
+			t.Fatalf("Create %s: %v", c.path, err)
+		}
+		if _, err := f.Write(c.data); err != nil {
+			t.Fatalf("Write %s: %v", c.path, err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("Close file %s: %v", c.path, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal("Writer.Close:", err)
+	}
+
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("Open:", err)
+	}
+
+	erofstest.CheckFileBytes(t, efs, "tiny.txt", tiny)
+	erofstest.CheckFileBytes(t, efs, "compressible.bin", compressible)
+	erofstest.CheckFileBytes(t, efs, "incompressible.bin", incompressible)
+	erofstest.CheckFileBytes(t, efs, "tailed.bin", tailed)
+	erofstest.CheckFileBytes(t, efs, "big-compressible.bin", bigCompressible)
+}

--- a/mkfs_test.go
+++ b/mkfs_test.go
@@ -3773,3 +3773,77 @@ func TestCreateFSCompressionLZ4(t *testing.T) {
 	erofstest.CheckFileBytes(t, efs, "tailed.bin", tailed)
 	erofstest.CheckFileBytes(t, efs, "big-compressible.bin", bigCompressible)
 }
+
+// TestReadAcceptsCompacted2BAdvise verifies the reader accepts images whose
+// z_erofs_map_header has the COMPACTED_2B advise bit set. Stock mkfs.erofs
+// emits this bit on any compact-layout image whose total lcluster count is
+// large enough to trigger the 2-byte-per-entry packed run; rejecting it
+// would block reading those images. The fix is checked synthetically by
+// flipping the bit on a writer-produced image (the writer doesn't emit
+// compact layout itself, but the advise bit is harmless for FULL layout
+// and the rejection happened in the shared map-header parser).
+func TestReadAcceptsCompacted2BAdvise(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf, erofs.WithCompression(erofs.CompressionLZ4))
+	data := bytes.Repeat([]byte("compressible data here\n"), 200)
+	f, err := w.Create("/file.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	img := buf.Bytes()
+
+	// Find file.bin's nid via the reader, then locate the map header by
+	// re-parsing the inode core ourselves.
+	efs, err := erofs.Open(bytes.NewReader(img))
+	if err != nil {
+		t.Fatal("Open:", err)
+	}
+	fi, err := fs.Stat(efs, "file.bin")
+	if err != nil {
+		t.Fatal("Stat:", err)
+	}
+	st := fi.Sys().(*erofs.Stat)
+
+	var sb disk.SuperBlock
+	if _, err := binary.Decode(img[disk.SuperBlockOffset:disk.SuperBlockOffset+disk.SizeSuperBlock], binary.LittleEndian, &sb); err != nil {
+		t.Fatal("decode superblock:", err)
+	}
+	blockSize := int64(1) << sb.BlkSizeBits
+	iloc := int64(sb.MetaBlkAddr)*blockSize + st.Ino*disk.SizeInodeCompact
+
+	format := binary.LittleEndian.Uint16(img[iloc : iloc+2])
+	layout := uint8((format & 0x0E) >> 1)
+	if layout != disk.LayoutCompressedFull {
+		t.Fatalf("expected LayoutCompressedFull (%d), got %d", disk.LayoutCompressedFull, layout)
+	}
+	icsize := int64(disk.SizeInodeCompact)
+	if format&0x01 != 0 {
+		icsize = disk.SizeInodeExtended
+	}
+	xattrIcount := binary.LittleEndian.Uint16(img[iloc+2 : iloc+4])
+	var xsize int64
+	if xattrIcount > 0 {
+		xsize = int64(xattrIcount-1)*disk.SizeXattrEntry + disk.SizeXattrBodyHeader
+	}
+	hdrPos := (iloc + icsize + xsize + 7) &^ 7
+
+	// HAdvise lives at bytes 4-5 of the 8-byte map header.
+	const hAdviseOff = 4
+	img[hdrPos+hAdviseOff] |= byte(disk.ZErofsAdviseCompacted2B)
+
+	efs2, err := erofs.Open(bytes.NewReader(img))
+	if err != nil {
+		t.Fatal("Open after setting COMPACTED_2B:", err)
+	}
+	erofstest.CheckFileBytes(t, efs2, "file.bin", data)
+}

--- a/mkfs_test.go
+++ b/mkfs_test.go
@@ -3847,3 +3847,67 @@ func TestReadAcceptsCompacted2BAdvise(t *testing.T) {
 	}
 	erofstest.CheckFileBytes(t, efs2, "file.bin", data)
 }
+
+// TestCreateFSCompressionBigPcluster verifies that compression with the big-
+// pcluster encoding actually shrinks images for compressible content and that
+// the result round-trips through the reader. Single-lcluster fallback for
+// incompressible content also keeps working.
+func TestCreateFSCompressionBigPcluster(t *testing.T) {
+	const blockSize = 4096
+
+	// Highly compressible: ~64 KiB of repeating text. The writer should
+	// group up to 4 lclusters per pcluster, so this file should land in
+	// roughly 64 KiB / 4 = 16 KiB of pclusters (plus index overhead).
+	bigCompressible := bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog\n"), 1500)
+
+	// Incompressible: random-ish bytes that LZ4 can't shrink. Each lcluster
+	// must fall back to PLAIN; the on-disk size should not be much smaller
+	// than the input.
+	incompressible := make([]byte, 8*blockSize)
+	for i := range incompressible {
+		incompressible[i] = byte(i*1103515245 + 12345)
+	}
+
+	var buf testBuffer
+	w := erofs.Create(&buf, erofs.WithCompression(erofs.CompressionLZ4))
+	for _, c := range []struct {
+		path string
+		data []byte
+	}{
+		{"/big.txt", bigCompressible},
+		{"/rand.bin", incompressible},
+	} {
+		f, err := w.Create(c.path)
+		if err != nil {
+			t.Fatalf("Create %s: %v", c.path, err)
+		}
+		if _, err := f.Write(c.data); err != nil {
+			t.Fatalf("Write %s: %v", c.path, err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("Close %s: %v", c.path, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal("Writer.Close:", err)
+	}
+
+	imgSize := int64(len(buf.Bytes()))
+	inputSize := int64(len(bigCompressible) + len(incompressible))
+	// big.txt is 66 KiB and should compress hugely; rand.bin is 32 KiB and
+	// stays roughly its size as PLAIN lclusters. An assertion that the
+	// image is at least ~30% smaller than the input is generous: with
+	// big-pcluster on, the compressible file alone should shrink ~4x.
+	if imgSize >= inputSize*7/10 {
+		t.Errorf("image size %d ≥ 70%% of input size %d — big-pcluster grouping didn't shrink output as expected", imgSize, inputSize)
+	}
+	t.Logf("image=%d bytes, input=%d bytes, ratio=%.1f%%",
+		imgSize, inputSize, 100*float64(imgSize)/float64(inputSize))
+
+	efs, err := erofs.Open(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal("Open:", err)
+	}
+	erofstest.CheckFileBytes(t, efs, "big.txt", bigCompressible)
+	erofstest.CheckFileBytes(t, efs, "rand.bin", incompressible)
+}

--- a/mkfs_test.go
+++ b/mkfs_test.go
@@ -3911,3 +3911,52 @@ func TestCreateFSCompressionBigPcluster(t *testing.T) {
 	erofstest.CheckFileBytes(t, efs, "big.txt", bigCompressible)
 	erofstest.CheckFileBytes(t, efs, "rand.bin", incompressible)
 }
+
+// TestReadRejectsBigPclusterWithoutSBFeature verifies the reader rejects an
+// image that sets BIG_PCLUSTER_1 in a per-inode map header but doesn't set
+// the matching superblock feature bit. The kernel rejects this combination
+// as -EFSCORRUPTED; we mirror that so a buggy writer is caught locally
+// instead of producing kernel-unreadable images that pass our own roundtrip.
+func TestReadRejectsBigPclusterWithoutSBFeature(t *testing.T) {
+	var buf testBuffer
+	w := erofs.Create(&buf, erofs.WithCompression(erofs.CompressionLZ4))
+	// Need enough data for the writer to emit a multi-lcluster pcluster.
+	data := bytes.Repeat([]byte("the quick brown fox\n"), 4096)
+	f, err := w.Create("/file.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	img := buf.Bytes()
+
+	// Sanity check: the image really uses BIG_PCLUSTER. If not, this test
+	// isn't exercising what it claims to.
+	const fiOff = disk.SuperBlockOffset + 80
+	sbFeatBefore := binary.LittleEndian.Uint32(img[fiOff : fiOff+4])
+	if sbFeatBefore&disk.FeatureIncompatBigPcluster == 0 {
+		t.Fatalf("writer didn't set BIG_PCLUSTER feature bit (feat=0x%x); test won't exercise the check", sbFeatBefore)
+	}
+
+	// Clear the BIG_PCLUSTER bit only, leaving LZ4_0PADDING etc. in place.
+	binary.LittleEndian.PutUint32(img[fiOff:fiOff+4], sbFeatBefore&^disk.FeatureIncompatBigPcluster)
+
+	efs, err := erofs.Open(bytes.NewReader(img))
+	if err != nil {
+		t.Fatal("Open:", err)
+	}
+	_, err = fs.ReadFile(efs, "file.bin")
+	if err == nil {
+		t.Fatal("expected ReadFile to fail when BIG_PCLUSTER_1 is set but sb feature is cleared")
+	}
+	if !errors.Is(err, erofs.ErrInvalid) {
+		t.Errorf("expected ErrInvalid, got %v", err)
+	}
+}

--- a/writer.go
+++ b/writer.go
@@ -1029,7 +1029,14 @@ func (w *erofsWriter) compressEntry(e *erofsEntry) error {
 			}
 		}
 
-		// Per-lcluster fallback: process each of the k blocks individually.
+		// Per-lcluster fallback: the K-block batch above either didn't
+		// compress (n == 0) or didn't compress small enough to save a
+		// physical block (m >= k). Re-compress each lcluster on its own so
+		// individual blocks can still pick HEAD1 or PLAIN, even though the
+		// batch as a whole couldn't share a pcluster. This costs roughly 2x
+		// compression CPU on incompressible inputs — the batch attempt is
+		// wasted — which is the trade-off for cheap big-pcluster opt-in
+		// without a separate scan phase.
 		for j := 0; j < k; j++ {
 			block := rawBatch[j*bs : (j+1)*bs]
 			n, err := w.comp.compressBlock(block, compressed)

--- a/writer.go
+++ b/writer.go
@@ -38,6 +38,17 @@ type erofsWriter struct {
 	zeroBuf     []byte                       // blockSize-length zero buffer for padding
 	inodeBuf    [disk.SizeInodeExtended]byte // scratch buffer for writeInode
 	compression Compression                  // compression algorithm for regular file data
+
+	// cspool holds the compressed bytes for every LayoutCompressedFull entry,
+	// appended sequentially during compressEntries and copied back to the
+	// output during writeDataBlocks. Using a tempfile (rather than a per-
+	// entry []byte) caps peak memory at O(scratch buffers) regardless of
+	// image size. Created lazily on the first compressed entry; the underlying
+	// file is unlinked immediately after open so it'll be reclaimed when the
+	// fd closes.
+	cspool    *os.File
+	cspoolOff int64
+	tempDir   string // mirror of fsys.tempDir for the cspool
 }
 
 // inodeSize returns the on-disk inode header size for e.
@@ -74,6 +85,7 @@ func (w *erofsWriter) minChunkBits(size uint64) uint8 {
 
 func (w *erofsWriter) write(out io.WriteSeeker) error {
 	w.copyBuf = make([]byte, 256*1024) // shared io.CopyBuffer buffer
+	defer w.closeCspool()
 	return w.writeSeekable(out)
 }
 
@@ -825,10 +837,12 @@ func (w *erofsWriter) flatPlainDataSize(e *erofsEntry) int {
 const maxPclusterLclusters = 4
 
 // compressEntries walks all entries and pre-compresses any LayoutCompressedFull
-// regular files into per-entry buffers. After this returns, each compressed
-// entry has its compressedData (nPblks blocks of bytes), lclusterEntries (one
-// per lcluster), and nPblks (actual physical block count) populated, so
-// assignDataBlocks and entryDataBlocks can use the real on-disk size.
+// regular files into the shared cspool tempfile. After this returns, each
+// compressed entry has its cspoolOff (start offset in the spool), nPblks
+// (physical block count, also = len(spool slice) / blockSize), and
+// lclusterEntries populated, so assignDataBlocks and entryDataBlocks can use
+// the real on-disk size. The cspool itself is unlinked on creation and
+// freed automatically when the writer closes it via closeCspool().
 func (w *erofsWriter) compressEntries() error {
 	for _, e := range w.entries {
 		if e.layout != disk.LayoutCompressedFull {
@@ -837,6 +851,40 @@ func (w *erofsWriter) compressEntries() error {
 		if err := w.compressEntry(e); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// ensureCspool lazily opens the shared compressed-data spool. The tempfile
+// is unlinked immediately so it disappears when the fd closes, matching the
+// raw-data spool in Writer.ensureSpool.
+func (w *erofsWriter) ensureCspool() error {
+	if w.cspool != nil {
+		return nil
+	}
+	tmp, err := os.CreateTemp(w.tempDir, "erofs-cdata-*")
+	if err != nil {
+		return fmt.Errorf("create compressed-data spool: %w", err)
+	}
+	_ = os.Remove(tmp.Name())
+	w.cspool = tmp
+	return nil
+}
+
+// closeCspool releases the spool fd. Safe to call multiple times.
+func (w *erofsWriter) closeCspool() {
+	if w.cspool != nil {
+		_ = w.cspool.Close()
+		w.cspool = nil
+	}
+}
+
+// cspoolWrite appends p to the cspool and advances cspoolOff.
+func (w *erofsWriter) cspoolWrite(p []byte) error {
+	n, err := w.cspool.Write(p)
+	w.cspoolOff += int64(n)
+	if err != nil {
+		return fmt.Errorf("write compressed-data spool: %w", err)
 	}
 	return nil
 }
@@ -866,17 +914,22 @@ func (w *erofsWriter) compressEntry(e *erofsEntry) error {
 		}
 	}()
 
+	if err := w.ensureCspool(); err != nil {
+		return err
+	}
+	e.cspoolOff = w.cspoolOff
+
 	bs := w.blockSize
 	nlcn := int(e.nLclusters)
 	e.lclusterEntries = make([]lclusterEntry, nlcn)
 
-	// Scratch buffers sized for the biggest batch.
+	// Scratch buffers sized for the biggest batch. These live on the stack
+	// frame and are released when compressEntry returns.
 	rawBatch := make([]byte, maxPclusterLclusters*bs)
 	compressedBatch := make([]byte, maxPclusterLclusters*bs)
 	// Per-block scratch used by the single-lcluster fallback.
 	compressed := make([]byte, bs)
 
-	var out []byte // accumulates exactly nPblks * blockSize bytes
 	remaining := int64(e.size)
 	pblk := uint32(0) // physical block index within the entry
 	i := 0
@@ -931,10 +984,14 @@ func (w *erofsWriter) compressEntry(e *erofsEntry) error {
 							delta1: uint16(k - j),
 						}
 					}
-					// Write m blocks of compressed data + zero pad.
-					out = append(out, compressedBatch[:n]...)
+					// Append m blocks of compressed data + zero pad to the spool.
+					if err := w.cspoolWrite(compressedBatch[:n]); err != nil {
+						return err
+					}
 					if pad := m*bs - n; pad > 0 {
-						out = append(out, make([]byte, pad)...)
+						if err := w.cspoolWrite(w.zeroBuf[:pad]); err != nil {
+							return err
+						}
 					}
 					pblk += uint32(m)
 					i += k
@@ -955,15 +1012,21 @@ func (w *erofsWriter) compressEntry(e *erofsEntry) error {
 					typ:  disk.ZErofsLclusterTypePlain,
 					pblk: pblk,
 				}
-				out = append(out, block...)
+				if err := w.cspoolWrite(block); err != nil {
+					return err
+				}
 			} else {
 				e.lclusterEntries[i+j] = lclusterEntry{
 					typ:  disk.ZErofsLclusterTypeHead1,
 					pblk: pblk,
 				}
-				out = append(out, compressed[:n]...)
+				if err := w.cspoolWrite(compressed[:n]); err != nil {
+					return err
+				}
 				if pad := bs - n; pad > 0 {
-					out = append(out, make([]byte, pad)...)
+					if err := w.cspoolWrite(w.zeroBuf[:pad]); err != nil {
+						return err
+					}
 				}
 			}
 			pblk++
@@ -971,21 +1034,20 @@ func (w *erofsWriter) compressEntry(e *erofsEntry) error {
 		i += k
 	}
 
-	e.compressedData = out
 	e.nPblks = pblk
-	if len(out) != int(pblk)*bs {
-		return fmt.Errorf("internal: %s emitted %d bytes for %d pblks (blockSize=%d)",
-			e.path, len(out), pblk, bs)
+	if w.cspoolOff-e.cspoolOff != int64(pblk)*int64(bs) {
+		return fmt.Errorf("internal: %s emitted %d spool bytes for %d pblks (blockSize=%d)",
+			e.path, w.cspoolOff-e.cspoolOff, pblk, bs)
 	}
 	return nil
 }
 
-// writeCompressedData writes the pre-computed compressed bytes for e. Block
-// addresses inside e.lclusterEntries are relative to the entry; here we
-// rewrite them with the absolute dataBlkAddr so writeCompressedTrailing can
-// emit them as-is.
+// writeCompressedData streams an entry's pre-compressed bytes from the spool
+// to the output. Block addresses inside e.lclusterEntries are relative to
+// the start of the entry's data area; here we rewrite them with the
+// absolute dataBlkAddr so writeCompressedTrailing can emit them as-is.
 func (w *erofsWriter) writeCompressedData(out io.Writer, e *erofsEntry) error {
-	if len(e.compressedData) == 0 {
+	if e.nPblks == 0 {
 		return nil
 	}
 	for idx := range e.lclusterEntries {
@@ -994,11 +1056,15 @@ func (w *erofsWriter) writeCompressedData(out io.Writer, e *erofsEntry) error {
 			le.pblk += e.dataBlkAddr
 		}
 	}
-	if _, err := out.Write(e.compressedData); err != nil {
-		return fmt.Errorf("write compressed data for %s: %w", e.path, err)
+	size := int64(e.nPblks) * int64(w.blockSize)
+	src := io.NewSectionReader(w.cspool, e.cspoolOff, size)
+	n, err := io.CopyBuffer(onlyWriter{out}, src, w.copyBuf)
+	if err != nil {
+		return fmt.Errorf("copy compressed data for %s: %w", e.path, err)
 	}
-	// Release the buffer once it's on disk.
-	e.compressedData = nil
+	if n != size {
+		return fmt.Errorf("short copy of compressed data for %s: got %d, want %d", e.path, n, size)
+	}
 	return nil
 }
 

--- a/writer.go
+++ b/writer.go
@@ -506,9 +506,7 @@ func (w *erofsWriter) writeXattrs(buf io.Writer, e *erofsEntry) error {
 // the reserved 8-byte slot before the lcluster index, and one
 // z_erofs_lcluster_index entry per logical cluster.
 //
-// Each lcluster maps to exactly one physical block (no big-pcluster); the
-// block address is e.dataBlkAddr + lclusterIndex. Type comes from
-// e.lclusterTypes which writeCompressedData populated.
+// Entries come from e.lclusterEntries which compressEntry populated.
 func (w *erofsWriter) writeCompressedTrailing(buf io.Writer, e *erofsEntry) error {
 	headerSize := inodeCoreSize(e) + e.xattrSize
 	alignPad := (8 - (headerSize % 8)) % 8
@@ -518,13 +516,19 @@ func (w *erofsWriter) writeCompressedTrailing(buf io.Writer, e *erofsEntry) erro
 		}
 	}
 
-	// z_erofs_map_header: 8 bytes. clusterbits=0 (lcluster=blocksize),
-	// algorithmtype=LZ4 in low nibble, h_advise=0, fragmentoff=0.
+	// z_erofs_map_header: clusterbits=0 (lcluster=blocksize),
+	// algorithmtype in the low nibble, h_advise carries BIG_PCLUSTER_1 if
+	// any pcluster spans more than one block.
 	algoID, _, err := pickCompressor(w.compression)
 	if err != nil {
 		return err
 	}
+	var hAdvise uint16
+	if entryHasBigPcluster(e) {
+		hAdvise |= disk.ZErofsAdviseBigPcluster1
+	}
 	var hdr [disk.SizeZErofsMapHeader]byte
+	binary.LittleEndian.PutUint16(hdr[4:6], hAdvise)
 	hdr[6] = algoID // h_algorithmtype: low nibble = HEAD1 algo
 	hdr[7] = 0      // h_clusterbits: lcluster_bits = blockSize_bits + 0
 	if _, err := buf.Write(hdr[:]); err != nil {
@@ -538,16 +542,36 @@ func (w *erofsWriter) writeCompressedTrailing(buf io.Writer, e *erofsEntry) erro
 
 	// One z_erofs_lcluster_index per lcluster.
 	var li [disk.SizeZErofsLclusterIndex]byte
-	for i := uint32(0); i < e.nLclusters; i++ {
-		typ := e.lclusterTypes[i]
-		binary.LittleEndian.PutUint16(li[0:2], uint16(typ)) // di_advise (type in low bits)
-		binary.LittleEndian.PutUint16(li[2:4], 0)           // di_clusterofs = 0
-		binary.LittleEndian.PutUint32(li[4:8], e.dataBlkAddr+i)
+	for _, le := range e.lclusterEntries {
+		binary.LittleEndian.PutUint16(li[0:2], uint16(le.typ))
+		if le.typ == disk.ZErofsLclusterTypeNonhead {
+			binary.LittleEndian.PutUint16(li[2:4], 0)
+			// NONHEAD packs delta[0] and delta[1] into di_u.
+			binary.LittleEndian.PutUint32(li[4:8],
+				uint32(le.delta0)|(uint32(le.delta1)<<16))
+		} else {
+			binary.LittleEndian.PutUint16(li[2:4], 0) // di_clusterofs = 0
+			binary.LittleEndian.PutUint32(li[4:8], le.pblk)
+		}
 		if _, err := buf.Write(li[:]); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// entryHasBigPcluster reports whether any pcluster of e spans more than one
+// physical block (signalled by a NONHEAD with CBLKCNT). When false the
+// emitted lcluster index is functionally equivalent to the single-block
+// encoding and the BIG_PCLUSTER_1 advise bit can be left off.
+func entryHasBigPcluster(e *erofsEntry) bool {
+	for _, le := range e.lclusterEntries {
+		if le.typ == disk.ZErofsLclusterTypeNonhead &&
+			le.delta0&disk.ZErofsLiD0CblkCnt != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // writeChunkIndexes writes chunk index entries for a regular file.
@@ -784,13 +808,42 @@ func (w *erofsWriter) flatPlainDataSize(e *erofsEntry) int {
 	return 0
 }
 
-// writeCompressedData compresses a regular file's data in blockSize-sized
-// chunks and writes one physical block per lcluster. For each chunk, if LZ4
-// produces output smaller than blockSize the block is HEAD1 (compressed,
-// zero-padded to a full block); otherwise the raw bytes are emitted as a
-// PLAIN lcluster. Per-block decisions are recorded in e.lclusterTypes and
-// consumed later by writeCompressedTrailing.
-func (w *erofsWriter) writeCompressedData(out io.Writer, e *erofsEntry) error {
+// maxPclusterLclusters is the maximum number of logical clusters the writer
+// will group into a single physical cluster. mkfs.erofs's default is 1; we
+// pick 4 so a typical lz4-compressed text/code file actually shrinks. The
+// kernel caps this at Z_EROFS_PCLUSTER_MAX_SIZE / blockSize (256 for a 4 KiB
+// block) and surfaces the choice via the lz4_cfgs.max_pclusterblks field.
+const maxPclusterLclusters = 4
+
+// compressEntries walks all entries and pre-compresses any LayoutCompressedFull
+// regular files into per-entry buffers. After this returns, each compressed
+// entry has its compressedData (nPblks blocks of bytes), lclusterEntries (one
+// per lcluster), and nPblks (actual physical block count) populated, so
+// assignDataBlocks and entryDataBlocks can use the real on-disk size.
+func (w *erofsWriter) compressEntries() error {
+	for _, e := range w.entries {
+		if e.layout != disk.LayoutCompressedFull {
+			continue
+		}
+		if err := w.compressEntry(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// compressEntry compresses one regular file's data, choosing per pcluster
+// between three encodings:
+//   - big-pcluster: K logical clusters share M < K physical blocks via a
+//     HEAD1 + (K-1) NONHEAD lcluster group, with CBLKCNT=M on the first
+//     NONHEAD;
+//   - HEAD1: one logical cluster, one physical block, LZ4 output < blockSize;
+//   - PLAIN: one logical cluster, one physical block, raw bytes (used when
+//     LZ4 doesn't shrink the input).
+//
+// Decisions are local to each batch of up to maxPclusterLclusters lclusters.
+// Empty / nil data files keep their planLayout layout and produce no data.
+func (w *erofsWriter) compressEntry(e *erofsEntry) error {
 	if e.size == 0 || e.data == nil {
 		return nil
 	}
@@ -798,62 +851,145 @@ func (w *erofsWriter) writeCompressedData(out io.Writer, e *erofsEntry) error {
 	if err != nil {
 		return fmt.Errorf("compressor for %s: %w", e.path, err)
 	}
+	defer func() {
+		if c, ok := e.data.(io.Closer); ok {
+			_ = c.Close()
+		}
+	}()
 
+	bs := w.blockSize
 	nlcn := int(e.nLclusters)
-	e.lclusterTypes = make([]uint8, nlcn)
+	e.lclusterEntries = make([]lclusterEntry, nlcn)
 
-	raw := make([]byte, w.blockSize)
-	compressed := make([]byte, w.blockSize)
-	zero := w.zeroBuf
+	// Scratch buffers sized for the biggest batch.
+	rawBatch := make([]byte, maxPclusterLclusters*bs)
+	compressedBatch := make([]byte, maxPclusterLclusters*bs)
+	// Per-block scratch used by the single-lcluster fallback.
+	compressed := make([]byte, bs)
 
+	var out []byte // accumulates exactly nPblks * blockSize bytes
 	remaining := int64(e.size)
-	for i := 0; i < nlcn; i++ {
-		want := int64(w.blockSize)
-		if want > remaining {
-			want = remaining
-		}
-		if _, err := io.ReadFull(e.data, raw[:want]); err != nil {
-			return fmt.Errorf("read data for %s: %w", e.path, err)
-		}
-		remaining -= want
-
-		// Zero any bytes in the last partial block beyond the file size so
-		// compression operates on a deterministic blockSize-sized input.
-		// Trying to compress only `want` bytes would still produce valid
-		// LZ4 output, but mkfs.erofs compresses the full lcluster size when
-		// big_pcluster is off; we match that.
-		if want < int64(w.blockSize) {
-			for j := int(want); j < w.blockSize; j++ {
-				raw[j] = 0
-			}
+	pblk := uint32(0) // physical block index within the entry
+	i := 0
+	for i < nlcn {
+		k := maxPclusterLclusters
+		if i+k > nlcn {
+			k = nlcn - i
 		}
 
-		n, err := comp.compressBlock(compressed, raw)
-		if err != nil {
-			return fmt.Errorf("compress data for %s: %w", e.path, err)
+		// Read k blocks worth into rawBatch. The last batch's final lcluster
+		// may be partial; zero-pad the tail so compression sees a deterministic
+		// k*blockSize input.
+		batchBytes := int64(k) * int64(bs)
+		actual := remaining
+		if actual > batchBytes {
+			actual = batchBytes
 		}
-		// Treat n==0 (LZ4 inflation) or "doesn't fit smaller" as plain.
-		if n <= 0 || n >= w.blockSize {
-			e.lclusterTypes[i] = disk.ZErofsLclusterTypePlain
-			if _, err := out.Write(raw); err != nil {
-				return fmt.Errorf("write plain block for %s: %w", e.path, err)
-			}
-			continue
-		}
-		e.lclusterTypes[i] = disk.ZErofsLclusterTypeHead1
-		if _, err := out.Write(compressed[:n]); err != nil {
-			return fmt.Errorf("write compressed block for %s: %w", e.path, err)
-		}
-		if pad := w.blockSize - n; pad > 0 {
-			if _, err := out.Write(zero[:pad]); err != nil {
-				return fmt.Errorf("write pad for %s: %w", e.path, err)
+		if actual > 0 {
+			if _, err := io.ReadFull(e.data, rawBatch[:actual]); err != nil {
+				return fmt.Errorf("read data for %s: %w", e.path, err)
 			}
 		}
+		clear(rawBatch[actual:batchBytes])
+		remaining -= actual
+
+		// First try big-pcluster: compress the whole batch as one LZ4 stream.
+		// If the result fits in fewer than k blocks, emit the multi-lcluster
+		// pcluster. Skip when k == 1 (degenerates to the per-lcluster path).
+		if k > 1 {
+			n, err := comp.compressBlock(compressedBatch, rawBatch[:batchBytes])
+			if err != nil {
+				return fmt.Errorf("compress batch for %s: %w", e.path, err)
+			}
+			if n > 0 && n < int(batchBytes) {
+				m := (n + bs - 1) / bs
+				if m < k {
+					// Emit the HEAD1 + NONHEADs.
+					e.lclusterEntries[i] = lclusterEntry{
+						typ:  disk.ZErofsLclusterTypeHead1,
+						pblk: pblk,
+					}
+					// First NONHEAD carries CBLKCNT = m.
+					e.lclusterEntries[i+1] = lclusterEntry{
+						typ:    disk.ZErofsLclusterTypeNonhead,
+						delta0: uint16(m) | disk.ZErofsLiD0CblkCnt,
+						delta1: uint16(k - 1),
+					}
+					for j := 2; j < k; j++ {
+						e.lclusterEntries[i+j] = lclusterEntry{
+							typ:    disk.ZErofsLclusterTypeNonhead,
+							delta0: uint16(j),
+							delta1: uint16(k - j),
+						}
+					}
+					// Write m blocks of compressed data + zero pad.
+					out = append(out, compressedBatch[:n]...)
+					if pad := m*bs - n; pad > 0 {
+						out = append(out, make([]byte, pad)...)
+					}
+					pblk += uint32(m)
+					i += k
+					continue
+				}
+			}
+		}
+
+		// Per-lcluster fallback: process each of the k blocks individually.
+		for j := 0; j < k; j++ {
+			block := rawBatch[j*bs : (j+1)*bs]
+			n, err := comp.compressBlock(compressed, block)
+			if err != nil {
+				return fmt.Errorf("compress block for %s: %w", e.path, err)
+			}
+			if n <= 0 || n >= bs {
+				e.lclusterEntries[i+j] = lclusterEntry{
+					typ:  disk.ZErofsLclusterTypePlain,
+					pblk: pblk,
+				}
+				out = append(out, block...)
+			} else {
+				e.lclusterEntries[i+j] = lclusterEntry{
+					typ:  disk.ZErofsLclusterTypeHead1,
+					pblk: pblk,
+				}
+				out = append(out, compressed[:n]...)
+				if pad := bs - n; pad > 0 {
+					out = append(out, make([]byte, pad)...)
+				}
+			}
+			pblk++
+		}
+		i += k
 	}
 
-	if c, ok := e.data.(io.Closer); ok {
-		_ = c.Close()
+	e.compressedData = out
+	e.nPblks = pblk
+	if len(out) != int(pblk)*bs {
+		return fmt.Errorf("internal: %s emitted %d bytes for %d pblks (blockSize=%d)",
+			e.path, len(out), pblk, bs)
 	}
+	return nil
+}
+
+// writeCompressedData writes the pre-computed compressed bytes for e. Block
+// addresses inside e.lclusterEntries are relative to the entry; here we
+// rewrite them with the absolute dataBlkAddr so writeCompressedTrailing can
+// emit them as-is.
+func (w *erofsWriter) writeCompressedData(out io.Writer, e *erofsEntry) error {
+	if len(e.compressedData) == 0 {
+		return nil
+	}
+	for idx := range e.lclusterEntries {
+		le := &e.lclusterEntries[idx]
+		if le.typ != disk.ZErofsLclusterTypeNonhead {
+			le.pblk += e.dataBlkAddr
+		}
+	}
+	if _, err := out.Write(e.compressedData); err != nil {
+		return fmt.Errorf("write compressed data for %s: %w", e.path, err)
+	}
+	// Release the buffer once it's on disk.
+	e.compressedData = nil
 	return nil
 }
 
@@ -872,8 +1008,9 @@ func (w *erofsWriter) entryDataBlocks(e *erofsEntry) int {
 		}
 		return (ds + w.blockSize - 1) / w.blockSize
 	case disk.LayoutCompressedFull:
-		// One physical block per lcluster (no big-pcluster support).
-		return int(e.nLclusters)
+		// compressEntry populates nPblks from the actual on-disk size, which
+		// may be less than nLclusters when big-pcluster grouping wins.
+		return int(e.nPblks)
 	}
 	return 0
 }

--- a/writer.go
+++ b/writer.go
@@ -959,7 +959,7 @@ func (w *erofsWriter) compressEntry(e *erofsEntry) error {
 		// If the result fits in fewer than k blocks, emit the multi-lcluster
 		// pcluster. Skip when k == 1 (degenerates to the per-lcluster path).
 		if k > 1 {
-			n, err := comp.compressBlock(compressedBatch, rawBatch[:batchBytes])
+			n, err := comp.compressBlock(rawBatch[:batchBytes], compressedBatch)
 			if err != nil {
 				return fmt.Errorf("compress batch for %s: %w", e.path, err)
 			}
@@ -1003,7 +1003,7 @@ func (w *erofsWriter) compressEntry(e *erofsEntry) error {
 		// Per-lcluster fallback: process each of the k blocks individually.
 		for j := 0; j < k; j++ {
 			block := rawBatch[j*bs : (j+1)*bs]
-			n, err := comp.compressBlock(compressed, block)
+			n, err := comp.compressBlock(block, compressed)
 			if err != nil {
 				return fmt.Errorf("compress block for %s: %w", e.path, err)
 			}

--- a/writer.go
+++ b/writer.go
@@ -37,6 +37,7 @@ type erofsWriter struct {
 	copyBuf     []byte                       // reusable buffer for io.CopyBuffer
 	zeroBuf     []byte                       // blockSize-length zero buffer for padding
 	inodeBuf    [disk.SizeInodeExtended]byte // scratch buffer for writeInode
+	compression Compression                  // compression algorithm for regular file data
 }
 
 // inodeSize returns the on-disk inode header size for e.
@@ -160,24 +161,18 @@ func (w *erofsWriter) assignDataBlocks() {
 		metaBlocks := (totalMetaBytes + w.blockSize - 1) / w.blockSize
 		addr := uint32(w.sbAreaBlocks() + metaBlocks)
 		for _, e := range w.entries {
-			if e.hardLinkPrimary != nil {
-				continue
-			}
-			if ds := w.flatPlainDataSize(e); ds > 0 {
+			if nblk := w.entryDataBlocks(e); nblk > 0 {
 				e.dataBlkAddr = addr
-				addr += uint32((ds + w.blockSize - 1) / w.blockSize)
+				addr += uint32(nblk)
 			}
 		}
 	} else {
 		// Data-first: data starts after superblock area.
 		addr := uint32(w.sbAreaBlocks())
 		for _, e := range w.entries {
-			if e.hardLinkPrimary != nil {
-				continue // secondary entries share the primary's data blocks
-			}
-			if ds := w.flatPlainDataSize(e); ds > 0 {
+			if nblk := w.entryDataBlocks(e); nblk > 0 {
 				e.dataBlkAddr = addr
-				addr += uint32((ds + w.blockSize - 1) / w.blockSize)
+				addr += uint32(nblk)
 			}
 		}
 		w.metaBlkAddr = addr // metadata follows data
@@ -228,15 +223,10 @@ func (w *erofsWriter) writeBlock0(buf io.Writer) error {
 	totalMetaBytes := w.metadataBytes()
 	metaBlocks := (totalMetaBytes + w.blockSize - 1) / w.blockSize
 
-	// Count data blocks (skip secondary hard-link entries).
+	// Count data blocks (flat-plain plus compressed pclusters).
 	dataBlocks := 0
 	for _, e := range w.entries {
-		if e.hardLinkPrimary != nil {
-			continue
-		}
-		if ds := w.flatPlainDataSize(e); ds > 0 {
-			dataBlocks += (ds + w.blockSize - 1) / w.blockSize
-		}
+		dataBlocks += w.entryDataBlocks(e)
 	}
 	totalBlocks := w.sbAreaBlocks() + metaBlocks + dataBlocks
 
@@ -249,10 +239,15 @@ func (w *erofsWriter) writeBlock0(buf io.Writer) error {
 		extraDevices = uint16(len(w.devices))
 		devtSlotOff = uint16(disk.SizeSuperBlock / 16)
 	}
+	var comprAlgs uint16
 	for _, e := range w.entries {
 		if len(e.chunks) > 0 {
 			featureIncompat |= disk.FeatureIncompatChunkedFile
-			break
+		}
+		if e.layout == disk.LayoutCompressedFull {
+			featureIncompat |= disk.FeatureIncompatLZ4_0Padding
+			algoID, _, _ := pickCompressor(w.compression)
+			comprAlgs |= 1 << algoID
 		}
 	}
 
@@ -266,6 +261,7 @@ func (w *erofsWriter) writeBlock0(buf io.Writer) error {
 		Blocks:          uint32(totalBlocks),
 		MetaBlkAddr:     w.metaBlkAddr,
 		FeatureIncompat: featureIncompat,
+		ComprAlgs:       comprAlgs,
 		ExtraDevices:    extraDevices,
 		DevtSlotOff:     devtSlotOff,
 	}
@@ -346,6 +342,11 @@ func (w *erofsWriter) writeMetadataInodes(buf io.Writer) error {
 					return fmt.Errorf("write chunks for %s: %w", e.path, err)
 				}
 				metaStart += e.trailingSize
+			} else if e.layout == disk.LayoutCompressedFull {
+				if err := w.writeCompressedTrailing(buf, e); err != nil {
+					return fmt.Errorf("write compressed metadata for %s: %w", e.path, err)
+				}
+				metaStart += e.trailingSize
 			} else if e.layout == disk.LayoutFlatInline && e.size > 0 && e.data != nil {
 				// e.data may be an unbounded reader (e.g. directData from CopyFrom);
 				// limit to e.size bytes to prevent overwriting subsequent metadata.
@@ -415,6 +416,8 @@ func (w *erofsWriter) writeInode(buf io.Writer, e *erofsEntry) error {
 		} else if e.layout == disk.LayoutFlatPlain && e.size > 0 {
 			inodeData = e.dataBlkAddr
 		}
+		// LayoutCompressedFull leaves inodeData=0; the algorithm and
+		// block addresses live in the trailing map header + lcluster index.
 	case disk.StatTypeDir, disk.StatTypeSymlink:
 		if e.layout == disk.LayoutFlatPlain {
 			inodeData = e.dataBlkAddr
@@ -493,6 +496,55 @@ func (w *erofsWriter) writeXattrs(buf io.Writer, e *erofsEntry) error {
 			if _, err := buf.Write(w.zeroBuf[:4-entryLen%4]); err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+// writeCompressedTrailing emits the on-disk trailing area for a
+// LayoutCompressedFull inode: alignment padding, the z_erofs_map_header,
+// the reserved 8-byte slot before the lcluster index, and one
+// z_erofs_lcluster_index entry per logical cluster.
+//
+// Each lcluster maps to exactly one physical block (no big-pcluster); the
+// block address is e.dataBlkAddr + lclusterIndex. Type comes from
+// e.lclusterTypes which writeCompressedData populated.
+func (w *erofsWriter) writeCompressedTrailing(buf io.Writer, e *erofsEntry) error {
+	headerSize := inodeCoreSize(e) + e.xattrSize
+	alignPad := (8 - (headerSize % 8)) % 8
+	if alignPad > 0 {
+		if _, err := buf.Write(w.zeroBuf[:alignPad]); err != nil {
+			return err
+		}
+	}
+
+	// z_erofs_map_header: 8 bytes. clusterbits=0 (lcluster=blocksize),
+	// algorithmtype=LZ4 in low nibble, h_advise=0, fragmentoff=0.
+	algoID, _, err := pickCompressor(w.compression)
+	if err != nil {
+		return err
+	}
+	var hdr [disk.SizeZErofsMapHeader]byte
+	hdr[6] = algoID // h_algorithmtype: low nibble = HEAD1 algo
+	hdr[7] = 0      // h_clusterbits: lcluster_bits = blockSize_bits + 0
+	if _, err := buf.Write(hdr[:]); err != nil {
+		return err
+	}
+
+	// 8 bytes reserved gap (Z_EROFS_FULL_INDEX_START = MAP_HEADER_END + 8).
+	if _, err := buf.Write(w.zeroBuf[:8]); err != nil {
+		return err
+	}
+
+	// One z_erofs_lcluster_index per lcluster.
+	var li [disk.SizeZErofsLclusterIndex]byte
+	for i := uint32(0); i < e.nLclusters; i++ {
+		typ := e.lclusterTypes[i]
+		binary.LittleEndian.PutUint16(li[0:2], uint16(typ)) // di_advise (type in low bits)
+		binary.LittleEndian.PutUint16(li[2:4], 0)           // di_clusterofs = 0
+		binary.LittleEndian.PutUint32(li[4:8], e.dataBlkAddr+i)
+		if _, err := buf.Write(li[:]); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -656,6 +708,12 @@ func (w *erofsWriter) writeDataBlocks(out io.Writer) error {
 		if e.hardLinkPrimary != nil {
 			continue // secondary hard-link entries share the primary's data blocks
 		}
+		if e.layout == disk.LayoutCompressedFull {
+			if err := w.writeCompressedData(out, e); err != nil {
+				return err
+			}
+			continue
+		}
 		ds := w.flatPlainDataSize(e)
 		if ds == 0 {
 			continue
@@ -722,6 +780,100 @@ func (w *erofsWriter) flatPlainDataSize(e *erofsEntry) int {
 		return w.direntDataSize(e)
 	case disk.StatTypeSymlink:
 		return len(e.symTarget)
+	}
+	return 0
+}
+
+// writeCompressedData compresses a regular file's data in blockSize-sized
+// chunks and writes one physical block per lcluster. For each chunk, if LZ4
+// produces output smaller than blockSize the block is HEAD1 (compressed,
+// zero-padded to a full block); otherwise the raw bytes are emitted as a
+// PLAIN lcluster. Per-block decisions are recorded in e.lclusterTypes and
+// consumed later by writeCompressedTrailing.
+func (w *erofsWriter) writeCompressedData(out io.Writer, e *erofsEntry) error {
+	if e.size == 0 || e.data == nil {
+		return nil
+	}
+	_, comp, err := pickCompressor(w.compression)
+	if err != nil {
+		return fmt.Errorf("compressor for %s: %w", e.path, err)
+	}
+
+	nlcn := int(e.nLclusters)
+	e.lclusterTypes = make([]uint8, nlcn)
+
+	raw := make([]byte, w.blockSize)
+	compressed := make([]byte, w.blockSize)
+	zero := w.zeroBuf
+
+	remaining := int64(e.size)
+	for i := 0; i < nlcn; i++ {
+		want := int64(w.blockSize)
+		if want > remaining {
+			want = remaining
+		}
+		if _, err := io.ReadFull(e.data, raw[:want]); err != nil {
+			return fmt.Errorf("read data for %s: %w", e.path, err)
+		}
+		remaining -= want
+
+		// Zero any bytes in the last partial block beyond the file size so
+		// compression operates on a deterministic blockSize-sized input.
+		// Trying to compress only `want` bytes would still produce valid
+		// LZ4 output, but mkfs.erofs compresses the full lcluster size when
+		// big_pcluster is off; we match that.
+		if want < int64(w.blockSize) {
+			for j := int(want); j < w.blockSize; j++ {
+				raw[j] = 0
+			}
+		}
+
+		n, err := comp.compressBlock(compressed, raw)
+		if err != nil {
+			return fmt.Errorf("compress data for %s: %w", e.path, err)
+		}
+		// Treat n==0 (LZ4 inflation) or "doesn't fit smaller" as plain.
+		if n <= 0 || n >= w.blockSize {
+			e.lclusterTypes[i] = disk.ZErofsLclusterTypePlain
+			if _, err := out.Write(raw); err != nil {
+				return fmt.Errorf("write plain block for %s: %w", e.path, err)
+			}
+			continue
+		}
+		e.lclusterTypes[i] = disk.ZErofsLclusterTypeHead1
+		if _, err := out.Write(compressed[:n]); err != nil {
+			return fmt.Errorf("write compressed block for %s: %w", e.path, err)
+		}
+		if pad := w.blockSize - n; pad > 0 {
+			if _, err := out.Write(zero[:pad]); err != nil {
+				return fmt.Errorf("write pad for %s: %w", e.path, err)
+			}
+		}
+	}
+
+	if c, ok := e.data.(io.Closer); ok {
+		_ = c.Close()
+	}
+	return nil
+}
+
+// entryDataBlocks returns the number of physical data blocks an entry will
+// occupy outside the metadata area. Used to size the on-disk data section
+// for block-address assignment and superblock accounting.
+func (w *erofsWriter) entryDataBlocks(e *erofsEntry) int {
+	if e.hardLinkPrimary != nil {
+		return 0 // secondary entries share the primary's data blocks
+	}
+	switch e.layout {
+	case disk.LayoutFlatPlain:
+		ds := w.flatPlainDataSize(e)
+		if ds == 0 {
+			return 0
+		}
+		return (ds + w.blockSize - 1) / w.blockSize
+	case disk.LayoutCompressedFull:
+		// One physical block per lcluster (no big-pcluster support).
+		return int(e.nLclusters)
 	}
 	return 0
 }

--- a/writer.go
+++ b/writer.go
@@ -97,11 +97,11 @@ func (w *erofsWriter) resolveCompressor() error {
 	if w.compResolved {
 		return nil
 	}
-	algoID, comp, err := pickCompressor(w.compression)
+	comp, err := pickCompressor(w.compression)
 	if err != nil {
 		return err
 	}
-	w.algoID = algoID
+	w.algoID = comp.algorithmID()
 	w.comp = comp
 	w.compResolved = true
 	return nil
@@ -374,7 +374,8 @@ func (w *erofsWriter) writeMetadataInodes(buf io.Writer) error {
 		// Write trailing data
 		switch e.mode & disk.StatTypeMask {
 		case disk.StatTypeReg:
-			if e.layout == disk.LayoutChunkBased && (e.size > 0 || len(e.chunks) > 0) {
+			switch {
+			case e.layout == disk.LayoutChunkBased && (e.size > 0 || len(e.chunks) > 0):
 				// Align the chunk-index map to the chunk-index unit.
 				if e.chunkPad > 0 {
 					if _, err := buf.Write(w.zeroBuf[:e.chunkPad]); err != nil {
@@ -386,12 +387,12 @@ func (w *erofsWriter) writeMetadataInodes(buf io.Writer) error {
 					return fmt.Errorf("write chunks for %s: %w", e.path, err)
 				}
 				metaStart += e.trailingSize
-			} else if e.layout == disk.LayoutCompressedFull {
+			case e.layout == disk.LayoutCompressedFull:
 				if err := w.writeCompressedTrailing(buf, e); err != nil {
 					return fmt.Errorf("write compressed metadata for %s: %w", e.path, err)
 				}
 				metaStart += e.trailingSize
-			} else if e.layout == disk.LayoutFlatInline && e.size > 0 && e.data != nil {
+			case e.layout == disk.LayoutFlatInline && e.size > 0 && e.data != nil:
 				// e.data may be an unbounded reader (e.g. directData from CopyFrom);
 				// limit to e.size bytes to prevent overwriting subsequent metadata.
 				expected := int64(e.size)

--- a/writer.go
+++ b/writer.go
@@ -856,6 +856,15 @@ func (w *erofsWriter) flatPlainDataSize(e *erofsEntry) int {
 // block) and surfaces the choice via the lz4_cfgs.max_pclusterblks field.
 const maxPclusterLclusters = 4
 
+// Compile-time guard: the on-disk CBLKCNT marker encodes the pcluster's
+// physical block count in 11 bits of NONHEAD di_u.delta[0] (the high bit at
+// ZErofsLiD0CblkCnt = 0x800 is the marker itself, the low 11 bits hold the
+// value). If maxPclusterLclusters ever exceeds 0x7FF (= ZErofsLiD0CblkCnt-1)
+// the OR in compressEntry would clobber the marker bit and emit a corrupt
+// index entry. Make the conversion below fail at build time before that
+// happens; if you legitimately need a larger value, widen the encoding.
+var _ [int(disk.ZErofsLiD0CblkCnt) - maxPclusterLclusters]struct{}
+
 // compressEntries walks all entries and pre-compresses any LayoutCompressedFull
 // regular files into the shared cspool tempfile. After this returns, each
 // compressed entry has its cspoolOff (start offset in the spool), nPblks

--- a/writer.go
+++ b/writer.go
@@ -248,6 +248,15 @@ func (w *erofsWriter) writeBlock0(buf io.Writer) error {
 			featureIncompat |= disk.FeatureIncompatLZ4_0Padding
 			algoID, _, _ := pickCompressor(w.compression)
 			comprAlgs |= 1 << algoID
+			// The kernel rejects images that use BIG_PCLUSTER_1 advise
+			// without the matching superblock feature bit ("per-inode
+			// big pcluster without sb feature" → -EFSCORRUPTED, see
+			// fs/erofs/zmap.c). Set FeatureIncompatBigPcluster as soon
+			// as any pcluster in the entry actually spans more than one
+			// block. The bit shares value 0x2 with COMPR_CFGS.
+			if entryHasBigPcluster(e) {
+				featureIncompat |= disk.FeatureIncompatBigPcluster
+			}
 		}
 	}
 

--- a/writer.go
+++ b/writer.go
@@ -289,7 +289,7 @@ func (w *erofsWriter) writeBlock0(buf io.Writer) error {
 			// fs/erofs/zmap.c). Set FeatureIncompatBigPcluster as soon
 			// as any pcluster in the entry actually spans more than one
 			// block. The bit shares value 0x2 with COMPR_CFGS.
-			if entryHasBigPcluster(e) {
+			if e.hasBigPcluster {
 				featureIncompat |= disk.FeatureIncompatBigPcluster
 			}
 		}
@@ -565,7 +565,7 @@ func (w *erofsWriter) writeCompressedTrailing(buf io.Writer, e *erofsEntry) erro
 	// any pcluster spans more than one block. The compressor was resolved
 	// during compressEntries so w.algoID is already set here.
 	var hAdvise uint16
-	if entryHasBigPcluster(e) {
+	if e.hasBigPcluster {
 		hAdvise |= disk.ZErofsAdviseBigPcluster1
 	}
 	var hdr [disk.SizeZErofsMapHeader]byte
@@ -599,20 +599,6 @@ func (w *erofsWriter) writeCompressedTrailing(buf io.Writer, e *erofsEntry) erro
 		}
 	}
 	return nil
-}
-
-// entryHasBigPcluster reports whether any pcluster of e spans more than one
-// physical block (signalled by a NONHEAD with CBLKCNT). When false the
-// emitted lcluster index is functionally equivalent to the single-block
-// encoding and the BIG_PCLUSTER_1 advise bit can be left off.
-func entryHasBigPcluster(e *erofsEntry) bool {
-	for _, le := range e.lclusterEntries {
-		if le.typ == disk.ZErofsLclusterTypeNonhead &&
-			le.delta0&disk.ZErofsLiD0CblkCnt != 0 {
-			return true
-		}
-	}
-	return false
 }
 
 // writeChunkIndexes writes chunk index entries for a regular file.
@@ -1035,6 +1021,7 @@ func (w *erofsWriter) compressEntry(e *erofsEntry) error {
 							return err
 						}
 					}
+					e.hasBigPcluster = true
 					pblk += uint32(m)
 					i += k
 					continue

--- a/writer.go
+++ b/writer.go
@@ -39,6 +39,12 @@ type erofsWriter struct {
 	inodeBuf    [disk.SizeInodeExtended]byte // scratch buffer for writeInode
 	compression Compression                  // compression algorithm for regular file data
 
+	// Compressor cache, resolved once when the writer needs to compress its
+	// first entry. comp is nil and algoID is 0 when compression == CompressionNone.
+	compResolved bool
+	algoID       uint8
+	comp         compressor
+
 	// cspool holds the compressed bytes for every LayoutCompressedFull entry,
 	// appended sequentially during compressEntries and copied back to the
 	// output during writeDataBlocks. Using a tempfile (rather than a per-
@@ -81,6 +87,24 @@ func (w *erofsWriter) minChunkBits(size uint64) uint8 {
 		bits++
 	}
 	return bits
+}
+
+// resolveCompressor populates w.algoID and w.comp from w.compression on the
+// first call. Subsequent calls are no-ops. Callers that don't actually need
+// the compressor (e.g., when there are no compressed entries) never invoke
+// it. Returns an error only for unsupported algorithms.
+func (w *erofsWriter) resolveCompressor() error {
+	if w.compResolved {
+		return nil
+	}
+	algoID, comp, err := pickCompressor(w.compression)
+	if err != nil {
+		return err
+	}
+	w.algoID = algoID
+	w.comp = comp
+	w.compResolved = true
+	return nil
 }
 
 func (w *erofsWriter) write(out io.WriteSeeker) error {
@@ -258,8 +282,7 @@ func (w *erofsWriter) writeBlock0(buf io.Writer) error {
 		}
 		if e.layout == disk.LayoutCompressedFull {
 			featureIncompat |= disk.FeatureIncompatLZ4_0Padding
-			algoID, _, _ := pickCompressor(w.compression)
-			comprAlgs |= 1 << algoID
+			comprAlgs |= 1 << w.algoID
 			// The kernel rejects images that use BIG_PCLUSTER_1 advise
 			// without the matching superblock feature bit ("per-inode
 			// big pcluster without sb feature" → -EFSCORRUPTED, see
@@ -539,19 +562,16 @@ func (w *erofsWriter) writeCompressedTrailing(buf io.Writer, e *erofsEntry) erro
 
 	// z_erofs_map_header: clusterbits=0 (lcluster=blocksize),
 	// algorithmtype in the low nibble, h_advise carries BIG_PCLUSTER_1 if
-	// any pcluster spans more than one block.
-	algoID, _, err := pickCompressor(w.compression)
-	if err != nil {
-		return err
-	}
+	// any pcluster spans more than one block. The compressor was resolved
+	// during compressEntries so w.algoID is already set here.
 	var hAdvise uint16
 	if entryHasBigPcluster(e) {
 		hAdvise |= disk.ZErofsAdviseBigPcluster1
 	}
 	var hdr [disk.SizeZErofsMapHeader]byte
 	binary.LittleEndian.PutUint16(hdr[4:6], hAdvise)
-	hdr[6] = algoID // h_algorithmtype: low nibble = HEAD1 algo
-	hdr[7] = 0      // h_clusterbits: lcluster_bits = blockSize_bits + 0
+	hdr[6] = w.algoID // h_algorithmtype: low nibble = HEAD1 algo
+	hdr[7] = 0        // h_clusterbits: lcluster_bits = blockSize_bits + 0
 	if _, err := buf.Write(hdr[:]); err != nil {
 		return err
 	}
@@ -844,6 +864,23 @@ const maxPclusterLclusters = 4
 // the real on-disk size. The cspool itself is unlinked on creation and
 // freed automatically when the writer closes it via closeCspool().
 func (w *erofsWriter) compressEntries() error {
+	// Resolve the compressor once. If no entry is compressed we skip the
+	// resolve and the writer's algoID/comp stay zero — that's fine because
+	// writeBlock0/writeCompressedTrailing only read them when at least one
+	// entry has LayoutCompressedFull.
+	hasCompressed := false
+	for _, e := range w.entries {
+		if e.layout == disk.LayoutCompressedFull {
+			hasCompressed = true
+			break
+		}
+	}
+	if !hasCompressed {
+		return nil
+	}
+	if err := w.resolveCompressor(); err != nil {
+		return fmt.Errorf("resolve compressor: %w", err)
+	}
 	for _, e := range w.entries {
 		if e.layout != disk.LayoutCompressedFull {
 			continue
@@ -904,10 +941,6 @@ func (w *erofsWriter) compressEntry(e *erofsEntry) error {
 	if e.size == 0 || e.data == nil {
 		return nil
 	}
-	_, comp, err := pickCompressor(w.compression)
-	if err != nil {
-		return fmt.Errorf("compressor for %s: %w", e.path, err)
-	}
 	defer func() {
 		if c, ok := e.data.(io.Closer); ok {
 			_ = c.Close()
@@ -959,7 +992,7 @@ func (w *erofsWriter) compressEntry(e *erofsEntry) error {
 		// If the result fits in fewer than k blocks, emit the multi-lcluster
 		// pcluster. Skip when k == 1 (degenerates to the per-lcluster path).
 		if k > 1 {
-			n, err := comp.compressBlock(rawBatch[:batchBytes], compressedBatch)
+			n, err := w.comp.compressBlock(rawBatch[:batchBytes], compressedBatch)
 			if err != nil {
 				return fmt.Errorf("compress batch for %s: %w", e.path, err)
 			}
@@ -1003,7 +1036,7 @@ func (w *erofsWriter) compressEntry(e *erofsEntry) error {
 		// Per-lcluster fallback: process each of the k blocks individually.
 		for j := 0; j < k; j++ {
 			block := rawBatch[j*bs : (j+1)*bs]
-			n, err := comp.compressBlock(block, compressed)
+			n, err := w.comp.compressBlock(block, compressed)
 			if err != nil {
 				return fmt.Errorf("compress block for %s: %w", e.path, err)
 			}

--- a/zmap.go
+++ b/zmap.go
@@ -1,0 +1,539 @@
+package erofs
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sync"
+
+	"github.com/erofs/go-erofs/internal/disk"
+)
+
+// zmapState is the per-inode compression metadata, lazily populated on the
+// first compressed read. It mirrors the subset of struct erofs_inode (the
+// kernel's z_erofs_fill_inode_lazy output) needed to resolve a logical
+// offset to a physical pcluster.
+type zmapState struct {
+	once         sync.Once
+	err          error
+	advise       uint16
+	lclusterBits uint8
+	algoType     [2]uint8 // [0]=HEAD1 algorithm, [1]=HEAD2 algorithm
+	// indexStart is the byte offset (in img.meta) of the first lcluster index.
+	// For COMPRESSED_FULL this is Z_EROFS_FULL_INDEX_START(end);
+	// for COMPRESSED_COMPACT it is round_up(end,8) + sizeof(map_header).
+	indexStart int64
+	// totalLcn is the total number of logical clusters for this inode.
+	totalLcn uint32
+
+	// Single-extent cache for sequential reads. cachedBuf holds the
+	// decompressed bytes for the extent at cachedExt; cachedValid is true
+	// when populated. Guarded by cacheMu.
+	cacheMu     sync.Mutex
+	cachedExt   zextent
+	cachedBuf   []byte
+	cachedValid bool
+}
+
+// zextent describes a single contiguous decompression extent backing a
+// logical region of the file.
+type zextent struct {
+	logicalStart  int64 // start of decompressed extent (lcn << lclusterBits + clusterofs)
+	logicalSize   int64 // decompressed size in bytes
+	physicalStart int64 // physical byte address (block * blocksize)
+	physicalSize  int64 // compressed size in bytes
+	algorithm     uint8 // disk.ZErofsCompressionLZ4 etc.
+	plain         bool  // PLAIN lcluster type — copy bytes through, no decompression
+}
+
+// maprec mirrors the kernel's z_erofs_maprecorder for a single lcluster.
+type maprec struct {
+	lcn         uint32
+	typ         uint8 // Z_EROFS_LCLUSTER_TYPE_*
+	clusterOfs  uint16
+	pblk        uint32
+	delta       [2]uint16
+	cblkcnt     uint32 // compressed block count when D0_CBLKCNT is set
+	partialRef  bool
+	headType    uint8 // set after a successful lookback walk
+}
+
+// zmapInit reads the inode's z_erofs_map_header and validates that the
+// inode uses only features we currently support.
+func (img *image) zmapInit(fi *inode) *zmapState {
+	if fi.zmap == nil {
+		fi.zmap = &zmapState{}
+	}
+	z := fi.zmap
+	z.once.Do(func() {
+		z.err = img.zmapInitLocked(fi, z)
+	})
+	return z
+}
+
+func (img *image) zmapInitLocked(fi *inode, z *zmapState) error {
+	inodeStart := img.metaStartPos() + int64(fi.nid*disk.SizeInodeCompact)
+	hdrPos := alignUp8(inodeStart + fi.flatDataOffset())
+
+	var hdrBuf [disk.SizeZErofsMapHeader]byte
+	if _, err := img.meta.ReadAt(hdrBuf[:], hdrPos); err != nil {
+		return fmt.Errorf("read z_erofs_map_header at %d: %w", hdrPos, err)
+	}
+	var h disk.ZErofsMapHeader
+	if _, err := binary.Decode(hdrBuf[:], binary.LittleEndian, &h); err != nil {
+		return fmt.Errorf("decode z_erofs_map_header: %w", err)
+	}
+
+	// Reject features this implementation does not support.
+	unsupported := h.HAdvise &^ uint16(0)
+	const acceptedAdvise = uint16(0) // none of the advanced bits are supported
+	if h.HAdvise &^ acceptedAdvise != 0 {
+		// Map specific bits to clearer messages.
+		switch {
+		case h.HAdvise&disk.ZErofsAdviseFragmentPcluster != 0:
+			return fmt.Errorf("fragment pcluster: %w", ErrNotImplemented)
+		case h.HAdvise&disk.ZErofsAdviseInlinePcluster != 0:
+			return fmt.Errorf("inline pcluster (tail-packing): %w", ErrNotImplemented)
+		case h.HAdvise&disk.ZErofsAdviseBigPcluster1 != 0,
+			h.HAdvise&disk.ZErofsAdviseBigPcluster2 != 0:
+			return fmt.Errorf("big pcluster: %w", ErrNotImplemented)
+		case h.HAdvise&disk.ZErofsAdviseInterlacedPcluster != 0:
+			return fmt.Errorf("interlaced pcluster: %w", ErrNotImplemented)
+		}
+		return fmt.Errorf("unsupported h_advise bits 0x%x: %w", unsupported, ErrNotImplemented)
+	}
+
+	// h_clusterbits high bit signals whole-file fragment storage; reject.
+	if h.ClusterBits>>7 != 0 {
+		return fmt.Errorf("packed-inode fragment: %w", ErrNotImplemented)
+	}
+
+	z.advise = h.HAdvise
+	z.lclusterBits = img.sb.BlkSizeBits + (h.ClusterBits & 0xf)
+	z.algoType[0] = h.AlgorithmType & 0xf
+	z.algoType[1] = h.AlgorithmType >> 4
+	if z.algoType[0] >= disk.ZErofsCompressionMax || z.algoType[1] >= disk.ZErofsCompressionMax {
+		return fmt.Errorf("algorithm types %d/%d: %w", z.algoType[0], z.algoType[1], ErrNotImplemented)
+	}
+
+	switch fi.inodeLayout {
+	case disk.LayoutCompressedFull:
+		// Lcluster index starts at MAP_HEADER_END(end) + 8 = round_up(end,8)+16.
+		z.indexStart = hdrPos + disk.SizeZErofsMapHeader + 8
+	case disk.LayoutCompressedCompact:
+		// Compact bit-packed entries start right after the map header.
+		z.indexStart = hdrPos + disk.SizeZErofsMapHeader
+		if z.lclusterBits > 14 {
+			return fmt.Errorf("compact lclusterbits %d > 14: %w", z.lclusterBits, ErrNotImplemented)
+		}
+	default:
+		return fmt.Errorf("inode layout %d is not compressed", fi.inodeLayout)
+	}
+
+	z.totalLcn = uint32((fi.size + (1<<z.lclusterBits) - 1) >> z.lclusterBits)
+	return nil
+}
+
+// loadLcluster reads the lcn-th lcluster index entry for fi into m. lookahead
+// requests that compact mode also fill m.delta[1] for the extent's end.
+func (img *image) loadLcluster(fi *inode, z *zmapState, lcn uint32, lookahead bool, m *maprec) error {
+	if lcn >= z.totalLcn {
+		return fmt.Errorf("lcn %d out of range (total %d): %w", lcn, z.totalLcn, ErrInvalid)
+	}
+	switch fi.inodeLayout {
+	case disk.LayoutCompressedFull:
+		return img.loadFullLcluster(z, lcn, m)
+	case disk.LayoutCompressedCompact:
+		return img.loadCompactLcluster(z, lcn, lookahead, m)
+	}
+	return fmt.Errorf("inode layout %d: %w", fi.inodeLayout, ErrInvalid)
+}
+
+func (img *image) loadFullLcluster(z *zmapState, lcn uint32, m *maprec) error {
+	pos := z.indexStart + int64(lcn)*disk.SizeZErofsLclusterIndex
+	var buf [disk.SizeZErofsLclusterIndex]byte
+	if _, err := img.meta.ReadAt(buf[:], pos); err != nil {
+		return fmt.Errorf("read lcluster %d at %d: %w", lcn, pos, err)
+	}
+	var li disk.ZErofsLclusterIndex
+	if _, err := binary.Decode(buf[:], binary.LittleEndian, &li); err != nil {
+		return fmt.Errorf("decode lcluster %d: %w", lcn, err)
+	}
+
+	m.lcn = lcn
+	m.cblkcnt = 0
+	m.partialRef = false
+	advise := li.DiAdvise
+	m.typ = uint8(advise & disk.ZErofsLclusterTypeMask)
+	if m.typ == disk.ZErofsLclusterTypeNonhead {
+		m.clusterOfs = uint16(1 << z.lclusterBits)
+		m.delta[0] = uint16(li.DiU & 0xFFFF)
+		m.delta[1] = uint16(li.DiU >> 16)
+		if m.delta[0]&disk.ZErofsLiD0CblkCnt != 0 {
+			// Big-pcluster signalling — we don't support it.
+			return fmt.Errorf("big-pcluster CBLKCNT: %w", ErrNotImplemented)
+		}
+	} else {
+		m.partialRef = advise&disk.ZErofsLiPartialRef != 0
+		m.clusterOfs = li.DiClusterOfs
+		m.pblk = li.DiU
+		m.delta[0] = 0
+		m.delta[1] = 0
+		if m.clusterOfs >= 1<<z.lclusterBits {
+			return fmt.Errorf("lcn %d: clusterofs %d > lcluster size: %w", lcn, m.clusterOfs, ErrInvalid)
+		}
+	}
+	return nil
+}
+
+// loadCompactLcluster mirrors z_erofs_load_compact_lcluster in erofs-utils.
+// Compact mode bit-packs lcluster entries: 4-byte initial alignment slots
+// (compact_4b) followed by an optional run of 2-byte entries (compact_2b),
+// then continuing compact_4b. Each pack has a trailing 32-bit field that
+// stores the base pblk for HEAD lclusters within the pack.
+func (img *image) loadCompactLcluster(z *zmapState, lcn uint32, lookahead bool, m *maprec) error {
+	ebase := z.indexStart
+	lclusterBits := z.lclusterBits
+
+	m.lcn = lcn
+	m.cblkcnt = 0
+	m.partialRef = false
+
+	// compacted_4b_initial aligns the start of the compact_2b run (if any)
+	// to a 32-byte boundary measured from disk position 0.
+	compacted4bInitial := ((32 - uint32(ebase%32)) / 4) & 7
+	var compacted2b uint32
+	if z.advise&disk.ZErofsAdviseCompacted2B != 0 && compacted4bInitial < z.totalLcn {
+		compacted2b = (z.totalLcn - compacted4bInitial) &^ 15
+	}
+
+	pos := ebase
+	amortShift := uint8(2) // log2(byte size of one packed entry) — start at 4B
+	if lcn >= compacted4bInitial {
+		pos += int64(compacted4bInitial) * 4
+		lcn -= compacted4bInitial
+		if lcn < compacted2b {
+			amortShift = 1
+		} else {
+			pos += int64(compacted2b) * 2
+			lcn -= compacted2b
+		}
+	}
+	pos += int64(lcn) << amortShift
+
+	var vcnt uint32
+	switch {
+	case amortShift == 2 && lclusterBits <= 14:
+		vcnt = 2
+	case amortShift == 1 && lclusterBits <= 12:
+		vcnt = 16
+	default:
+		return fmt.Errorf("compact layout vcnt for amortShift=%d lclusterBits=%d: %w",
+			amortShift, lclusterBits, ErrNotImplemented)
+	}
+
+	packBytes := vcnt << amortShift
+	packStart := pos - (pos & int64(packBytes-1))
+	pack := make([]byte, packBytes)
+	if _, err := img.meta.ReadAt(pack, packStart); err != nil {
+		return fmt.Errorf("read compact pack at %d: %w", packStart, err)
+	}
+
+	lobits := uint(lclusterBits)
+	if cblkBits := uint(12); lobits < cblkBits {
+		lobits = cblkBits // ilog2(Z_EROFS_LI_D0_CBLKCNT)+1 = ilog2(2048)+1 = 12
+	}
+	encodebits := ((uint(packBytes) - 4) * 8) / uint(vcnt)
+	i := uint32(pos-packStart) >> amortShift
+
+	lo, typ := decodeCompactedBits(lobits, pack, encodebits*uint(i))
+	m.typ = typ
+	if typ == disk.ZErofsLclusterTypeNonhead {
+		m.clusterOfs = uint16(1 << lclusterBits)
+		if lookahead {
+			m.delta[1] = uint16(getCompactedLaDistance(lobits, encodebits, vcnt, pack, i))
+		}
+		if lo&disk.ZErofsLiD0CblkCnt != 0 {
+			return fmt.Errorf("big-pcluster CBLKCNT: %w", ErrNotImplemented)
+		}
+		if i+1 != vcnt {
+			m.delta[0] = uint16(lo)
+			return nil
+		}
+		// Last entry in the pack: lo encodes delta[1]. Walk back one step.
+		lo2, typ2 := decodeCompactedBits(lobits, pack, encodebits*uint(i-1))
+		if typ2 != disk.ZErofsLclusterTypeNonhead {
+			lo2 = 0
+		} else if lo2&disk.ZErofsLiD0CblkCnt != 0 {
+			lo2 = 1
+		}
+		m.delta[0] = uint16(lo2 + 1)
+		return nil
+	}
+
+	m.clusterOfs = uint16(lo)
+	m.delta[0] = 0
+	if m.clusterOfs >= 1<<lclusterBits {
+		return fmt.Errorf("compact lcn: clusterofs %d > lcluster size: %w", m.clusterOfs, ErrInvalid)
+	}
+
+	// Compute the HEAD pblk by walking forward from the pack base, counting
+	// the number of HEAD lclusters before this one within the pack. The
+	// pack's trailing 32-bit field stores the first HEAD's pblk.
+	var nblk uint32 = 1
+	for j := int(i) - 1; j >= 0; j-- {
+		lo2, typ2 := decodeCompactedBits(lobits, pack, encodebits*uint(j))
+		if typ2 == disk.ZErofsLclusterTypeNonhead {
+			j -= int(lo2)
+		}
+		if j >= 0 {
+			nblk++
+		}
+	}
+	pblk := binary.LittleEndian.Uint32(pack[packBytes-4:])
+	m.pblk = pblk + nblk
+	return nil
+}
+
+func decodeCompactedBits(lobits uint, in []byte, pos uint) (uint32, uint8) {
+	byteOff := pos / 8
+	// Read up to 4 bytes from byteOff and shift. Use a wider read to handle
+	// alignment, but guard the slice length.
+	var v uint32
+	switch {
+	case byteOff+4 <= uint(len(in)):
+		v = binary.LittleEndian.Uint32(in[byteOff:])
+	case byteOff+3 <= uint(len(in)):
+		v = uint32(in[byteOff]) | uint32(in[byteOff+1])<<8 | uint32(in[byteOff+2])<<16
+	case byteOff+2 <= uint(len(in)):
+		v = uint32(in[byteOff]) | uint32(in[byteOff+1])<<8
+	case byteOff+1 <= uint(len(in)):
+		v = uint32(in[byteOff])
+	}
+	v >>= pos & 7
+	lo := v & ((1 << lobits) - 1)
+	typ := uint8((v >> lobits) & 3)
+	return lo, typ
+}
+
+func getCompactedLaDistance(lobits, encodebits uint, vcnt uint32, in []byte, i uint32) uint32 {
+	var d1 uint32
+	var lo uint32
+	for j := i; j < vcnt; j++ {
+		l, typ := decodeCompactedBits(lobits, in, encodebits*uint(j))
+		lo = l
+		if typ != disk.ZErofsLclusterTypeNonhead {
+			return d1
+		}
+		d1++
+	}
+	if lo&disk.ZErofsLiD0CblkCnt == 0 {
+		d1 += lo - 1
+	}
+	return d1
+}
+
+// extentLookback walks back through NONHEAD lclusters until a HEAD is found.
+// On success m points at the HEAD lcluster and m.headType is set.
+func (img *image) extentLookback(fi *inode, z *zmapState, m *maprec, distance uint16) error {
+	for distance > 0 && m.lcn >= uint32(distance) {
+		lcn := m.lcn - uint32(distance)
+		if err := img.loadLcluster(fi, z, lcn, false, m); err != nil {
+			return err
+		}
+		switch m.typ {
+		case disk.ZErofsLclusterTypeNonhead:
+			distance = m.delta[0]
+			if distance == 0 {
+				return fmt.Errorf("zero lookback at lcn %d: %w", lcn, ErrInvalid)
+			}
+		case disk.ZErofsLclusterTypePlain,
+			disk.ZErofsLclusterTypeHead1,
+			disk.ZErofsLclusterTypeHead2:
+			m.headType = m.typ
+			return nil
+		default:
+			return fmt.Errorf("unknown lcluster type %d at lcn %d: %w", m.typ, lcn, ErrInvalid)
+		}
+	}
+	return fmt.Errorf("bad lookback distance %d at lcn %d: %w", distance, m.lcn, ErrInvalid)
+}
+
+// zmapLookup resolves a logical file offset to its containing pcluster.
+// The returned extent's logical range covers a single HEAD pcluster's worth
+// of decompressed data.
+func (img *image) zmapLookup(fi *inode, ofs int64) (zextent, error) {
+	z := img.zmapInit(fi)
+	if z.err != nil {
+		return zextent{}, z.err
+	}
+	if ofs < 0 || ofs >= fi.size {
+		return zextent{}, fmt.Errorf("offset %d out of range: %w", ofs, ErrInvalid)
+	}
+
+	lclusterBits := z.lclusterBits
+	initialLcn := uint32(ofs >> lclusterBits)
+	endoff := uint32(ofs & ((1 << lclusterBits) - 1))
+
+	var m maprec
+	if err := img.loadLcluster(fi, z, initialLcn, false, &m); err != nil {
+		return zextent{}, err
+	}
+
+	end := int64(m.lcn+1) << lclusterBits
+	switch m.typ {
+	case disk.ZErofsLclusterTypePlain,
+		disk.ZErofsLclusterTypeHead1,
+		disk.ZErofsLclusterTypeHead2:
+		if endoff >= uint32(m.clusterOfs) {
+			m.headType = m.typ
+			break
+		}
+		if m.lcn == 0 {
+			return zextent{}, fmt.Errorf("invalid lcluster 0 at nid %d: %w", fi.nid, ErrInvalid)
+		}
+		end = (int64(m.lcn) << lclusterBits) | int64(m.clusterOfs)
+		m.delta[0] = 1
+		fallthrough
+	case disk.ZErofsLclusterTypeNonhead:
+		if err := img.extentLookback(fi, z, &m, m.delta[0]); err != nil {
+			return zextent{}, err
+		}
+	default:
+		return zextent{}, fmt.Errorf("unknown lcluster type %d: %w", m.typ, ErrInvalid)
+	}
+
+	headLcn := m.lcn
+	headPblk := m.pblk
+	clusterOfs := m.clusterOfs
+	logicalStart := (int64(headLcn) << lclusterBits) | int64(clusterOfs)
+
+	compressedBlks, err := img.extentCompressedLen(fi, z, &m)
+	if err != nil {
+		return zextent{}, err
+	}
+
+	blockSize := int64(1) << img.sb.BlkSizeBits
+	ext := zextent{
+		logicalStart:  logicalStart,
+		logicalSize:   end - logicalStart,
+		physicalStart: int64(headPblk) << img.sb.BlkSizeBits,
+		physicalSize:  int64(compressedBlks) * blockSize,
+		plain:         m.headType == disk.ZErofsLclusterTypePlain,
+	}
+	if m.headType == disk.ZErofsLclusterTypeHead2 {
+		ext.algorithm = z.algoType[1]
+	} else {
+		ext.algorithm = z.algoType[0]
+	}
+	// Clamp logicalSize to the file size — the last pcluster may produce
+	// less than a full lcluster's worth of decompressed bytes.
+	if ext.logicalStart+ext.logicalSize > fi.size {
+		ext.logicalSize = fi.size - ext.logicalStart
+	}
+	return ext, nil
+}
+
+// extentCompressedLen returns the on-disk block count of the pcluster anchored
+// at m. Without big-pcluster support this is always 1.
+func (img *image) extentCompressedLen(fi *inode, z *zmapState, m *maprec) (uint32, error) {
+	// big-pcluster is not supported, so every HEAD pcluster is exactly one block.
+	_ = fi
+	_ = z
+	_ = m
+	return 1, nil
+}
+
+func alignUp8(v int64) int64 {
+	return (v + 7) &^ 7
+}
+
+// readCompressed reads up to blockSize bytes of decompressed data starting at
+// the given logical file position. It uses the per-inode pcluster cache so
+// sequential reads pay decompression cost once per pcluster.
+//
+// The returned slice points into the inode's cache buffer; callers must not
+// retain it across subsequent reads of the same inode.
+func (img *image) readCompressed(fi *inode, pos int64) ([]byte, error) {
+	z := img.zmapInit(fi)
+	if z.err != nil {
+		return nil, z.err
+	}
+
+	z.cacheMu.Lock()
+	defer z.cacheMu.Unlock()
+
+	if !z.cachedValid || pos < z.cachedExt.logicalStart ||
+		pos >= z.cachedExt.logicalStart+z.cachedExt.logicalSize {
+		ext, err := img.zmapLookup(fi, pos)
+		if err != nil {
+			return nil, err
+		}
+		if err := img.fillExtent(fi, &ext, z); err != nil {
+			return nil, err
+		}
+	}
+
+	offsetInExt := pos - z.cachedExt.logicalStart
+	blockSize := int64(1) << img.sb.BlkSizeBits
+	end := offsetInExt + blockSize
+	if end > int64(len(z.cachedBuf)) {
+		end = int64(len(z.cachedBuf))
+	}
+	return z.cachedBuf[offsetInExt:end], nil
+}
+
+// fillExtent reads the on-disk pcluster for ext and decompresses it into
+// z.cachedBuf. Called with z.cacheMu held.
+func (img *image) fillExtent(fi *inode, ext *zextent, z *zmapState) error {
+	// Resolve physical address through the device table (extra device
+	// support comes for free this way).
+	reader, addr, err := img.mapDev(0, ext.physicalStart)
+	if err != nil {
+		return fmt.Errorf("map device for nid %d: %w", fi.nid, err)
+	}
+
+	src := make([]byte, ext.physicalSize)
+	if _, err := reader.ReadAt(src, addr); err != nil {
+		return fmt.Errorf("read pcluster at %d for nid %d: %w", addr, fi.nid, err)
+	}
+
+	// Trim LZ4_0Padding zero bytes when the feature flag is set. The
+	// encoder may insert leading zero bytes within a pcluster block to
+	// align the compressed payload; the LZ4 block decoder treats a
+	// 0-prefix as no-op (length=0 literal/match), but trimming it
+	// keeps decoded sizes predictable.
+	if img.sb.FeatureIncompat&disk.FeatureIncompatLZ4_0Padding != 0 && !ext.plain {
+		for len(src) > 0 && src[0] == 0 {
+			src = src[1:]
+		}
+	}
+
+	if cap(z.cachedBuf) < int(ext.logicalSize) {
+		z.cachedBuf = make([]byte, ext.logicalSize)
+	} else {
+		z.cachedBuf = z.cachedBuf[:ext.logicalSize]
+	}
+
+	if ext.plain {
+		// PLAIN lcluster type: the on-disk bytes ARE the logical bytes.
+		copy(z.cachedBuf, src)
+	} else {
+		d, err := pickDecompressor(ext.algorithm)
+		if err != nil {
+			return err
+		}
+		n, err := d.decompress(z.cachedBuf, src)
+		if err != nil {
+			return fmt.Errorf("decompress nid %d at logical %d: %w", fi.nid, ext.logicalStart, err)
+		}
+		if n < len(z.cachedBuf) {
+			// Last pcluster of file may produce fewer bytes than a full lcluster.
+			z.cachedBuf = z.cachedBuf[:n]
+		}
+	}
+
+	z.cachedExt = *ext
+	z.cachedExt.logicalSize = int64(len(z.cachedBuf))
+	z.cachedValid = true
+	return nil
+}

--- a/zmap.go
+++ b/zmap.go
@@ -418,7 +418,6 @@ func (img *image) zmapLookup(fi *inode, ofs int64) (zextent, error) {
 		return zextent{}, err
 	}
 
-	end := int64(m.lcn+1) << lclusterBits
 	switch m.typ {
 	case disk.ZErofsLclusterTypePlain,
 		disk.ZErofsLclusterTypeHead1,
@@ -430,7 +429,6 @@ func (img *image) zmapLookup(fi *inode, ofs int64) (zextent, error) {
 		if m.lcn == 0 {
 			return zextent{}, fmt.Errorf("invalid lcluster 0 at nid %d: %w", fi.nid, ErrInvalid)
 		}
-		end = (int64(m.lcn) << lclusterBits) | int64(m.clusterOfs)
 		m.delta[0] = 1
 		fallthrough
 	case disk.ZErofsLclusterTypeNonhead:
@@ -455,11 +453,10 @@ func (img *image) zmapLookup(fi *inode, ofs int64) (zextent, error) {
 	// terminator's clusterofs marks the partial-tail end of this extent.
 	// Single-lcluster pclusters get exactly one lcluster's worth; multi-
 	// lcluster extents (big-pcluster or dedup'd) cover several.
-	endByte, err := img.extentDecompressedEnd(fi, z, headLcn)
+	end, err := img.extentDecompressedEnd(fi, z, headLcn)
 	if err != nil {
 		return zextent{}, err
 	}
-	end = endByte
 
 	blockSize := int64(1) << img.sb.BlkSizeBits
 	ext := zextent{

--- a/zmap.go
+++ b/zmap.go
@@ -488,9 +488,11 @@ func (img *image) zmapLookup(fi *inode, ofs int64) (zextent, error) {
 // previous extent's partial tail), so we can't just round to a whole
 // lcluster.
 //
-// Mirrors z_erofs_get_extent_decompressedlen in fs/erofs/zmap.c.
+// Mirrors z_erofs_get_extent_decompressedlen in fs/erofs/zmap.c. The walk
+// starts at headLcn+1 — zmapLookup has already loaded and classified the
+// HEAD at headLcn, so re-reading it would be wasted I/O.
 func (img *image) extentDecompressedEnd(fi *inode, z *zmapState, headLcn uint32) (int64, error) {
-	lcn := headLcn
+	lcn := headLcn + 1
 	for {
 		if int64(lcn)<<z.lclusterBits >= fi.size {
 			return fi.size, nil
@@ -510,11 +512,7 @@ func (img *image) extentDecompressedEnd(fi *inode, z *zmapState, headLcn uint32)
 			}
 			lcn += uint32(d1)
 		default:
-			if lcn != headLcn {
-				return int64(lcn)<<z.lclusterBits + int64(m.clusterOfs), nil
-			}
-			// First HEAD — start the walk one ahead.
-			lcn++
+			return int64(lcn)<<z.lclusterBits + int64(m.clusterOfs), nil
 		}
 	}
 }

--- a/zmap.go
+++ b/zmap.go
@@ -84,9 +84,12 @@ func (img *image) zmapInitLocked(fi *inode, z *zmapState) error {
 	}
 
 	// Reject features this implementation does not support.
-	unsupported := h.HAdvise &^ uint16(0)
-	const acceptedAdvise = uint16(0) // none of the advanced bits are supported
-	if h.HAdvise &^ acceptedAdvise != 0 {
+	//
+	// Compacted2B is the layout hint for the compact lcluster index — it
+	// just says the index uses a 2-byte-per-entry run in addition to the
+	// 4-byte run, and the compact decoder consults it directly. Accept it.
+	const acceptedAdvise = uint16(disk.ZErofsAdviseCompacted2B)
+	if unsupported := h.HAdvise &^ acceptedAdvise; unsupported != 0 {
 		// Map specific bits to clearer messages.
 		switch {
 		case h.HAdvise&disk.ZErofsAdviseFragmentPcluster != 0:

--- a/zmap.go
+++ b/zmap.go
@@ -279,9 +279,16 @@ func (img *image) loadCompactLcluster(z *zmapState, lcn uint32, lookahead bool, 
 		return fmt.Errorf("compact lcn: clusterofs %d > lcluster size: %w", m.clusterOfs, ErrInvalid)
 	}
 
-	// Compute the HEAD pblk by walking forward from the pack base, counting
-	// the number of HEAD lclusters before this one within the pack. The
-	// pack's trailing 32-bit field stores the first HEAD's pblk.
+	// Compute the HEAD pblk for entry i within the pack.
+	//
+	// Mirrors the non-big-pcluster branch of kernel z_erofs_load_compact_lcluster
+	// (fs/erofs/zmap.c:200-211). The pack's trailing 32-bit field stores
+	// `first_HEAD_pblk - 1`, not the first HEAD's pblk directly — i.e. the
+	// formula is `pblk_for_entry_i = base + nblk` where nblk starts at 1
+	// and increments once per HEAD-lcluster predecessor (NONHEADs jump
+	// back to the HEAD they reference). For i == 0 (we are the first HEAD)
+	// the loop never runs, nblk stays at 1, and we recover the first HEAD's
+	// real pblk = base + 1.
 	var nblk uint32 = 1
 	for j := int(i) - 1; j >= 0; j-- {
 		lo2, typ2 := decodeCompactedBits(lobits, pack, encodebits*uint(j))

--- a/zmap.go
+++ b/zmap.go
@@ -502,6 +502,10 @@ func (img *image) fillExtent(fi *inode, ext *zextent, z *zmapState) error {
 		return fmt.Errorf("map device for nid %d: %w", fi.nid, err)
 	}
 
+	if ext.physicalSize <= 0 || ext.physicalSize > disk.MaxPclusterSize {
+		return fmt.Errorf("pcluster size %d out of range (max %d) for nid %d: %w",
+			ext.physicalSize, disk.MaxPclusterSize, fi.nid, ErrInvalid)
+	}
 	src := make([]byte, ext.physicalSize)
 	if _, err := reader.ReadAt(src, addr); err != nil {
 		return fmt.Errorf("read pcluster at %d for nid %d: %w", addr, fi.nid, err)

--- a/zmap.go
+++ b/zmap.go
@@ -146,11 +146,13 @@ func (img *image) zmapInitLocked(fi *inode, z *zmapState) error {
 	case disk.LayoutCompressedCompact:
 		// Compact bit-packed entries start right after the map header.
 		z.indexStart = hdrPos + disk.SizeZErofsMapHeader
+		// lclusterbits is bounded by the spec; > 14 is invalid encoding,
+		// not a feature gap.
 		if z.lclusterBits > 14 {
-			return fmt.Errorf("compact lclusterbits %d > 14: %w", z.lclusterBits, ErrNotImplemented)
+			return fmt.Errorf("compact lclusterbits %d > 14: %w", z.lclusterBits, ErrInvalid)
 		}
 	default:
-		return fmt.Errorf("inode layout %d is not compressed", fi.inodeLayout)
+		return fmt.Errorf("inode layout %d is not compressed: %w", fi.inodeLayout, ErrInvalid)
 	}
 
 	z.totalLcn = uint32((fi.size + (1<<z.lclusterBits) - 1) >> z.lclusterBits)

--- a/zmap.go
+++ b/zmap.go
@@ -107,6 +107,24 @@ func (img *image) zmapInitLocked(fi *inode, z *zmapState) error {
 		}
 		return fmt.Errorf("unsupported h_advise bits 0x%x: %w", unsupported, ErrNotImplemented)
 	}
+	// Mirror the kernel's consistency check (fs/erofs/zmap.c): BIG_PCLUSTER_1
+	// in h_advise must agree with the superblock's BIG_PCLUSTER feature bit.
+	// An image that sets the per-inode bit without the sb feature is rejected
+	// by the kernel as -EFSCORRUPTED; reject it here too so writers that
+	// forget the sb bit fail loudly rather than silently producing
+	// kernel-unreadable images.
+	if h.HAdvise&disk.ZErofsAdviseBigPcluster1 != 0 &&
+		img.sb.FeatureIncompat&disk.FeatureIncompatBigPcluster == 0 {
+		return fmt.Errorf("BIG_PCLUSTER_1 advise without sb feature bit for nid %d: %w",
+			fi.nid, ErrInvalid)
+	}
+	// COMPRESSED_COMPACT + BIG_PCLUSTER_1 needs a separate pblk loop the
+	// compact decoder doesn't yet implement (see fs/erofs/zmap.c:212-233).
+	// Reject the combination up front rather than failing mid-read.
+	if fi.inodeLayout == disk.LayoutCompressedCompact &&
+		h.HAdvise&disk.ZErofsAdviseBigPcluster1 != 0 {
+		return fmt.Errorf("big pcluster in compact layout: %w", ErrNotImplemented)
+	}
 
 	// h_clusterbits high bit signals whole-file fragment storage; reject.
 	if h.ClusterBits>>7 != 0 {

--- a/zmap.go
+++ b/zmap.go
@@ -47,14 +47,16 @@ type zextent struct {
 
 // maprec mirrors the kernel's z_erofs_maprecorder for a single lcluster.
 type maprec struct {
-	lcn         uint32
-	typ         uint8 // Z_EROFS_LCLUSTER_TYPE_*
-	clusterOfs  uint16
-	pblk        uint32
-	delta       [2]uint16
-	cblkcnt     uint32 // compressed block count when D0_CBLKCNT is set
-	partialRef  bool
-	headType    uint8 // set after a successful lookback walk
+	lcn        uint32
+	typ        uint8 // Z_EROFS_LCLUSTER_TYPE_*
+	clusterOfs uint16
+	pblk       uint32
+	delta      [2]uint16
+	// compressedBlks is set when CBLKCNT is decoded on a NONHEAD lcluster;
+	// it carries the on-disk block count of the preceding pcluster.
+	compressedBlks uint32
+	partialRef     bool
+	headType       uint8 // set after a successful lookback walk
 }
 
 // zmapInit reads the inode's z_erofs_map_header and validates that the
@@ -87,8 +89,10 @@ func (img *image) zmapInitLocked(fi *inode, z *zmapState) error {
 	//
 	// Compacted2B is the layout hint for the compact lcluster index — it
 	// just says the index uses a 2-byte-per-entry run in addition to the
-	// 4-byte run, and the compact decoder consults it directly. Accept it.
-	const acceptedAdvise = uint16(disk.ZErofsAdviseCompacted2B)
+	// 4-byte run, and the compact decoder consults it directly.
+	// BigPcluster1 enables multi-block pclusters for HEAD1 lclusters,
+	// signalled per-pcluster via the CBLKCNT marker on the first NONHEAD.
+	const acceptedAdvise = uint16(disk.ZErofsAdviseCompacted2B | disk.ZErofsAdviseBigPcluster1)
 	if unsupported := h.HAdvise &^ acceptedAdvise; unsupported != 0 {
 		// Map specific bits to clearer messages.
 		switch {
@@ -96,9 +100,8 @@ func (img *image) zmapInitLocked(fi *inode, z *zmapState) error {
 			return fmt.Errorf("fragment pcluster: %w", ErrNotImplemented)
 		case h.HAdvise&disk.ZErofsAdviseInlinePcluster != 0:
 			return fmt.Errorf("inline pcluster (tail-packing): %w", ErrNotImplemented)
-		case h.HAdvise&disk.ZErofsAdviseBigPcluster1 != 0,
-			h.HAdvise&disk.ZErofsAdviseBigPcluster2 != 0:
-			return fmt.Errorf("big pcluster: %w", ErrNotImplemented)
+		case h.HAdvise&disk.ZErofsAdviseBigPcluster2 != 0:
+			return fmt.Errorf("big pcluster 2 (HEAD2): %w", ErrNotImplemented)
 		case h.HAdvise&disk.ZErofsAdviseInterlacedPcluster != 0:
 			return fmt.Errorf("interlaced pcluster: %w", ErrNotImplemented)
 		}
@@ -163,7 +166,7 @@ func (img *image) loadFullLcluster(z *zmapState, lcn uint32, m *maprec) error {
 	}
 
 	m.lcn = lcn
-	m.cblkcnt = 0
+	m.compressedBlks = 0
 	m.partialRef = false
 	advise := li.DiAdvise
 	m.typ = uint8(advise & disk.ZErofsLclusterTypeMask)
@@ -172,8 +175,14 @@ func (img *image) loadFullLcluster(z *zmapState, lcn uint32, m *maprec) error {
 		m.delta[0] = uint16(li.DiU & 0xFFFF)
 		m.delta[1] = uint16(li.DiU >> 16)
 		if m.delta[0]&disk.ZErofsLiD0CblkCnt != 0 {
-			// Big-pcluster signalling — we don't support it.
-			return fmt.Errorf("big-pcluster CBLKCNT: %w", ErrNotImplemented)
+			// Big-pcluster CBLKCNT: delta[0] carries the on-disk block
+			// count of the preceding pcluster (low 11 bits) and the
+			// implicit lookback distance to the HEAD is 1.
+			if z.advise&disk.ZErofsAdviseBigPcluster1 == 0 {
+				return fmt.Errorf("CBLKCNT without BIG_PCLUSTER_1 advise: %w", ErrInvalid)
+			}
+			m.compressedBlks = uint32(m.delta[0]) &^ disk.ZErofsLiD0CblkCnt
+			m.delta[0] = 1
 		}
 	} else {
 		m.partialRef = advise&disk.ZErofsLiPartialRef != 0
@@ -198,7 +207,7 @@ func (img *image) loadCompactLcluster(z *zmapState, lcn uint32, lookahead bool, 
 	lclusterBits := z.lclusterBits
 
 	m.lcn = lcn
-	m.cblkcnt = 0
+	m.compressedBlks = 0
 	m.partialRef = false
 
 	// compacted_4b_initial aligns the start of the compact_2b run (if any)
@@ -422,6 +431,16 @@ func (img *image) zmapLookup(fi *inode, ofs int64) (zextent, error) {
 		return zextent{}, err
 	}
 
+	// Walk forward via delta[1] to find the next HEAD/PLAIN (or EOF) — that
+	// terminator's clusterofs marks the partial-tail end of this extent.
+	// Single-lcluster pclusters get exactly one lcluster's worth; multi-
+	// lcluster extents (big-pcluster or dedup'd) cover several.
+	endByte, err := img.extentDecompressedEnd(fi, z, headLcn)
+	if err != nil {
+		return zextent{}, err
+	}
+	end = endByte
+
 	blockSize := int64(1) << img.sb.BlkSizeBits
 	ext := zextent{
 		logicalStart:  logicalStart,
@@ -443,13 +462,76 @@ func (img *image) zmapLookup(fi *inode, ofs int64) (zextent, error) {
 	return ext, nil
 }
 
+// extentDecompressedEnd walks the lcluster index forward from headLcn using
+// delta[1] until it lands on a new HEAD/PLAIN (or runs off the end of the
+// file). Returns the logical end byte offset of the current extent —
+// i.e., (next_HEAD_lcn << lclusterBits) + next_HEAD.clusterofs. The
+// terminating HEAD/PLAIN may carry a non-zero clusterofs (signalling the
+// previous extent's partial tail), so we can't just round to a whole
+// lcluster.
+//
+// Mirrors z_erofs_get_extent_decompressedlen in fs/erofs/zmap.c.
+func (img *image) extentDecompressedEnd(fi *inode, z *zmapState, headLcn uint32) (int64, error) {
+	lcn := headLcn
+	for {
+		if int64(lcn)<<z.lclusterBits >= fi.size {
+			return fi.size, nil
+		}
+		if lcn >= z.totalLcn {
+			return int64(z.totalLcn) << z.lclusterBits, nil
+		}
+		var m maprec
+		if err := img.loadLcluster(fi, z, lcn, true, &m); err != nil {
+			return 0, err
+		}
+		switch m.typ {
+		case disk.ZErofsLclusterTypeNonhead:
+			d1 := m.delta[1]
+			if d1 == 0 {
+				d1 = 1 // workaround for older mkfs.erofs that wrote d1=0
+			}
+			lcn += uint32(d1)
+		default:
+			if lcn != headLcn {
+				return int64(lcn)<<z.lclusterBits + int64(m.clusterOfs), nil
+			}
+			// First HEAD — start the walk one ahead.
+			lcn++
+		}
+	}
+}
+
 // extentCompressedLen returns the on-disk block count of the pcluster anchored
-// at m. Without big-pcluster support this is always 1.
+// at the HEAD lcluster in m. Mirrors z_erofs_get_extent_compressedlen in
+// fs/erofs/zmap.c — for big-pcluster images the count is recovered from the
+// CBLKCNT marker on the first NONHEAD lcluster that follows m.
 func (img *image) extentCompressedLen(fi *inode, z *zmapState, m *maprec) (uint32, error) {
-	// big-pcluster is not supported, so every HEAD pcluster is exactly one block.
-	_ = fi
-	_ = z
-	_ = m
+	// HEAD2 / PLAIN big-pcluster (BIG_PCLUSTER_2) isn't implemented in the
+	// writer, and the reader rejects the advise bit, so anything other than
+	// a HEAD1 anchored pcluster in big-pcluster mode is unambiguously 1 block.
+	if z.advise&disk.ZErofsAdviseBigPcluster1 == 0 ||
+		m.headType != disk.ZErofsLclusterTypeHead1 {
+		return 1, nil
+	}
+	nextLcn := m.lcn + 1
+	if int64(nextLcn)<<z.lclusterBits >= fi.size {
+		// HEAD is the last lcluster of the file — exactly one block.
+		return 1, nil
+	}
+
+	// Re-use the caller's maprec for the next lcluster; the caller doesn't
+	// reuse m after this point in the lookup path.
+	var next maprec
+	if err := img.loadLcluster(fi, z, nextLcn, false, &next); err != nil {
+		return 0, err
+	}
+	if next.typ == disk.ZErofsLclusterTypeNonhead && next.compressedBlks > 0 {
+		return next.compressedBlks, nil
+	}
+	// The next lcluster is either a fresh HEAD/PLAIN (new pcluster) or a
+	// NONHEAD without CBLKCNT — either way, the current pcluster is one
+	// block. Matches the kernel's "if (m->type != NONHEAD || !compressedblks)"
+	// fallback.
 	return 1, nil
 }
 

--- a/zmap.go
+++ b/zmap.go
@@ -155,7 +155,7 @@ func (img *image) zmapInitLocked(fi *inode, z *zmapState) error {
 		return fmt.Errorf("inode layout %d is not compressed: %w", fi.inodeLayout, ErrInvalid)
 	}
 
-	z.totalLcn = uint32((fi.size + (1<<z.lclusterBits) - 1) >> z.lclusterBits)
+	z.totalLcn = uint32((fi.size + (1 << z.lclusterBits) - 1) >> z.lclusterBits)
 	return nil
 }
 


### PR DESCRIPTION
Adds LZ4 support to both halves of the library: the reader accepts
LZ4-compressed images produced by stock `mkfs.erofs`, and the writer can
produce them via a new option. Images written by this branch mount and
read correctly under the real kernel erofs driver.

## API

One new writer option; everything else is internal.

```go
w := erofs.Create(out, erofs.WithCompression(erofs.CompressionLZ4))
```

`Compression` is a new exported type with `CompressionNone` (the
default, unchanged behavior) and `CompressionLZ4`. Reading needs no API
change — compressed inodes are transparent through `fs.FS`.

## Read path

Parses the `z_erofs` map header and lcluster index in both **FULL** and
**COMPACT** formats, then decompresses each pcluster on demand with a
per-inode cache. Includes an in-tree LZ4 block decoder
(`decompressor.go`) that stops at output capacity, so the trailing zero
padding inside a pcluster is ignored — the same semantics as the
kernel's `LZ4_decompress_safe_partial`. No cgo.

## Write path

Emits `COMPRESSED_FULL` inodes. Compression happens between
`planLayout` and the data write so the real on-disk block count is known
before block addresses are assigned.

Crucially this includes **big-pcluster (`BIG_PCLUSTER_1`)**: up to 4
consecutive logical clusters can share one physical pcluster. Without
it, every lcluster maps to exactly one block and
`WithCompression(CompressionLZ4)` yields an image the same size as — or
slightly larger than — the uncompressed equivalent, which defeats the
point of enabling it. When a batch doesn't shrink, the writer falls back
to per-lcluster `HEAD1`/`PLAIN` encoding.

Compressed bytes are spooled to a single unlinked tempfile rather than
per-entry `[]byte` buffers, so peak memory is O(scratch buffers) rather
than proportional to the total compressed size of the image. That
matters for multi-GB images of compressible content.

## Out of scope (explicit `ErrNotImplemented`)

Deferred features fail with a clear error at inode open rather than
mid-read: fragments, inline pcluster (tail-packing), `BIG_PCLUSTER_2` /
`HEAD2`, interlaced pclusters, packed-inode fragments, big-pcluster in
the compact layout, and non-LZ4 algorithms (LZMA / DEFLATE / Zstd).

## Robustness

The decoder parses untrusted on-disk bytes, so the branch carries a few
deliberate hardening changes:

- Physical pcluster size is bounded by `MaxPclusterSize` (1 MiB,
  matching the kernel's `Z_EROFS_PCLUSTER_MAX_SIZE`) **before**
  allocating the read buffer.
- A zero offset in the LZ4 stream is treated as corruption unless the
  output buffer is full, instead of silently returning a short decode
  that could mask filesystem damage.
- The reader rejects per-inode `BIG_PCLUSTER_1` when the superblock
  lacks `FEATURE_INCOMPAT_BIG_PCLUSTER`, mirroring the kernel's
  `-EFSCORRUPTED`. This exact inconsistency shipped briefly mid-branch
  and the kernel rejected every read while our reader was happy.
- A compile-time guard fails the build if `maxPclusterLclusters` is ever
  raised past 2047, where it would silently clobber the `CBLKCNT`
  marker bit and produce corrupt images.
- Corrupt-input paths consistently wrap `ErrInvalid` so `errors.Is` can
  distinguish them from `ErrNotImplemented` and from I/O errors.
- `decompressor_fuzz_test.go` fuzzes the partial LZ4 decoder for
  panics, infinite loops, and writes past `dst`.

## Testing

`go test ./...` passes. Coverage added: LZ4 round-trip through our own
writer and reader (inline, compressible, incompressible, partial-tail,
multi-block), a big-pcluster test asserting the image is under 70% of
the input size, compact-layout `COMPACTED_2B` decode, and synthetic
regression tests for the two reader rejection paths above.

Because the Go suite only exercises this library's reader against its
own writer, it can't catch on-disk encoding bugs that pass the
self-consistent loop but fail under the real kernel driver — which is
precisely what happened with the missing superblock feature bit. So
this also adds an opt-in kernel-mount test (`kernelmount_test.go`,
gated on `EROFS_KERNEL_TESTS=1`) that builds a compressed image, mounts
it via loopback, and verifies every file reads back byte-identical. It's
off by default because it needs Linux + passwordless sudo + the erofs
module, and it skips rather than hanging when sudo is unavailable —
making it a one-line CI gate on a privileged runner.

The subtests against stock `mkfs.erofs` skip when it isn't installed.

## Note: new dependency

This adds `github.com/pierrec/lz4/v4` for LZ4 block **compression**
(the write path). Decompression is in-tree with no dependency, so the
read path stays dependency-free. The README's "no CGO, standard library
only" claim is updated accordingly. Happy to vendor or hand-roll the
compressor instead if a zero-dependency library is a hard requirement.

## Relationship to #36

PR #36 (@katexochen) adds LZ4 **read** support for the full lcluster
layout and overlaps with this branch's read path, though the two took
different structural approaches — #36 introduces an `internal/zerofs`
package, this branch keeps the read path in `zmap.go` and adds compact
layout, big-pcluster, and the write path. Happy to rebase this on top
of #36 and reduce it to the write half plus the compact/big-pcluster
reader additions, if that's the preferred sequencing. Flagging rather
than assuming.
